### PR TITLE
Event Tagging Workflow

### DIFF
--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/SignUpActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/SignUpActivity.java
@@ -74,7 +74,7 @@ public class SignUpActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 // Hide keyboard
-                Utilities.hideSoftKeyboard(SignUpActivity.this);
+                //Utilities.hideSoftKeyboard(SignUpActivity.this);
                 loadRegistrationValues();
                 registerUser();
             }
@@ -120,7 +120,10 @@ public class SignUpActivity extends AppCompatActivity {
                             // If the registration was successful, direct user to the MainActivity
                             Intent i = MainActivity.newIntent(SignUpActivity.this);
                             startActivityForResult(i, REQUEST_CODE_CALCULATE);
-                            sendUserInfo("1", fname, lname, email, password, teamID);
+
+                            String userID = Utilities.createRandomHex(6);
+
+                            sendUserInfo(userID, fname, lname, email, password, teamID);
                             LoginActivity.loginActivity.finish(); // Kill LoginActivity from the backstack
                             finish(); // Don't add to the backstack
                         } else {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -334,7 +334,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Send stats
-                sendGameStats(eventDate, 0, 0, 0, pitchCounter, strikes, balls,
+                sendGameStats(0, eventName, eventDate, 0, 0, pitchCounter, strikes, balls,
                         count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
                         count_R3C1, count_R3C2, count_R3C3);
             }
@@ -383,11 +383,11 @@ public class TaggingActivity extends Activity {
         pitcherSet = true;
     }
 
-    private void sendGameStats(String eventDate, int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    private void sendGameStats(int gameID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
         // Defaulting some statistics to 0 until we establish further IDs
-        EventStats gameStats = new EventStats(eventDate, gameID, playerID, teamID, pitchCount, strikeCount, ballCount,
+        EventStats gameStats = new EventStats(gameID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count);
 

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -16,7 +16,12 @@ import android.widget.TextView;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 
-import pitcherseye.pitcherseye.Objects.GameStats;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+import pitcherseye.pitcherseye.Objects.EventStats;
 import pitcherseye.pitcherseye.R;
 
 public class TaggingActivity extends Activity {
@@ -62,6 +67,8 @@ public class TaggingActivity extends Activity {
     Boolean eventSet = false;
     Boolean isGame;
     Boolean isHome;
+    DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
+    String eventDate = df.format(Calendar.getInstance().getTime());
 
     // Statistic counts
     int pitchCounter = 0;
@@ -327,7 +334,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Send stats
-                sendGameStats(0, 0, 0, pitchCounter, strikes, balls,
+                sendGameStats(eventDate, 0, 0, 0, pitchCounter, strikes, balls,
                         count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
                         count_R3C1, count_R3C2, count_R3C3);
             }
@@ -376,15 +383,15 @@ public class TaggingActivity extends Activity {
         pitcherSet = true;
     }
 
-    private void sendGameStats(int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    private void sendGameStats(String eventDate, int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
         // Defaulting some statistics to 0 until we establish further IDs
-        GameStats gameStats = new GameStats(gameID, playerID, teamID, pitchCount, strikeCount, ballCount,
+        EventStats gameStats = new EventStats(eventDate, gameID, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count);
 
-        mDatabase.child("pitchingStats").child(Integer.toString(gameID)).setValue(gameStats);
+        mDatabase.child("eventStats").child(Integer.toString(gameID)).setValue(gameStats);
     }
 
     public static Intent newIntent(Context packageContext) {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -3,14 +3,11 @@ package pitcherseye.pitcherseye.Activities;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.View;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
-import android.widget.Switch;
 import android.widget.TextView;
 
 import com.google.firebase.database.DatabaseReference;
@@ -19,10 +16,10 @@ import com.google.firebase.database.FirebaseDatabase;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
-import java.util.Date;
 
 import pitcherseye.pitcherseye.Objects.EventStats;
 import pitcherseye.pitcherseye.R;
+import pitcherseye.pitcherseye.Utilities;
 
 public class TaggingActivity extends Activity {
 
@@ -72,7 +69,6 @@ public class TaggingActivity extends Activity {
 
     // Statistic counts
     int pitchCounter = 0;
-    int[] totalPitchCount = new int[pitchCounter];
     int strikes = 0;
     int balls = 0;
 
@@ -333,8 +329,11 @@ public class TaggingActivity extends Activity {
         mFinishGame.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
+                // Create the eventID and save with this event
+                String eventID = Utilities.createRandomHex(6);
+
                 // Send stats
-                sendGameStats(0, eventName, eventDate, 0, 0, pitchCounter, strikes, balls,
+                sendGameStats(eventID, eventName, eventDate, 0, 0, pitchCounter, strikes, balls,
                         count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
                         count_R3C1, count_R3C2, count_R3C3);
             }
@@ -383,15 +382,15 @@ public class TaggingActivity extends Activity {
         pitcherSet = true;
     }
 
-    private void sendGameStats(int gameID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    private void sendGameStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
         // Defaulting some statistics to 0 until we establish further IDs
-        EventStats gameStats = new EventStats(gameID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
+        EventStats gameStats = new EventStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count);
 
-        mDatabase.child("eventStats").child(Integer.toString(gameID)).setValue(gameStats);
+        mDatabase.child("eventStats").child(eventID).setValue(gameStats);
     }
 
     public static Intent newIntent(Context packageContext) {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -98,15 +98,25 @@ public class TaggingActivity extends Activity {
     int pitcherOtherCount = 0;
 
     // Location counts
-    int count_R1C1 = 0;
-    int count_R1C2 = 0;
-    int count_R1C3 = 0;
-    int count_R2C1 = 0;
-    int count_R2C2 = 0;
-    int count_R2C3 = 0;
-    int count_R3C1 = 0;
-    int count_R3C2 = 0;
-    int count_R3C3 = 0;
+    int eventCount_R1C1 = 0;
+    int eventCount_R1C2 = 0;
+    int eventCount_R1C3 = 0;
+    int eventCount_R2C1 = 0;
+    int eventCount_R2C2 = 0;
+    int eventCount_R2C3 = 0;
+    int eventCount_R3C1 = 0;
+    int eventCount_R3C2 = 0;
+    int eventCount_R3C3 = 0;
+
+    int pitcherCount_R1C1 = 0;
+    int pitcherCount_R1C2 = 0;
+    int pitcherCount_R1C3 = 0;
+    int pitcherCount_R2C1 = 0;
+    int pitcherCount_R2C2 = 0;
+    int pitcherCount_R2C3 = 0;
+    int pitcherCount_R3C1 = 0;
+    int pitcherCount_R3C2 = 0;
+    int pitcherCount_R3C3 = 0;
 
 
     @Override
@@ -175,7 +185,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R1C1;
+                ++eventCount_R1C1;
+
+                // Increase pitcher region count
+                ++pitcherCount_R1C1;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -192,7 +205,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R1C2;
+                ++eventCount_R1C2;
+
+                // Increase pitcher region count
+                ++pitcherCount_R1C2;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -208,7 +224,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R1C3;
+                ++eventCount_R1C3;
+
+                // Increase pitcher region count
+                ++pitcherCount_R1C3;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -224,7 +243,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R2C1;
+                ++eventCount_R2C1;
+
+                // Increase pitcher region count
+                ++pitcherCount_R2C1;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -240,7 +262,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R2C2;
+                ++eventCount_R2C2;
+
+                // Increase pitcher region count
+                ++pitcherCount_R2C2;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -256,7 +281,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R2C3;
+                ++eventCount_R2C3;
+
+                // Increase pitcher region count
+                ++pitcherCount_R2C3;
 
                 // Notify that we've selected the location for the workflow
                 //locationSelected = false;
@@ -273,7 +301,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R3C1;
+                ++eventCount_R3C1;
+
+                // Increase pitcher region count
+                ++pitcherCount_R3C1;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -289,7 +320,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R3C2;
+                ++eventCount_R3C2;
+
+                // Increase pitcher region count
+                ++pitcherCount_R3C2;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -305,7 +339,10 @@ public class TaggingActivity extends Activity {
                 mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
-                ++count_R3C3;
+                ++eventCount_R3C3;
+
+                // Increase pitcher region count
+                ++pitcherCount_R3C3;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -319,6 +356,9 @@ public class TaggingActivity extends Activity {
                 // Increase count
                 mFastballCount.setText(Integer.toString(++eventFastballCount));
 
+                // Increase pitcher count
+                ++pitcherFastballCount;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -329,6 +369,9 @@ public class TaggingActivity extends Activity {
             public void onClick(View view) {
                 // Increase count
                 mChangeupCount.setText(Integer.toString(++eventChangeupCount));
+
+                // Increase pitcher count
+                ++pitcherChangeupCount;
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -341,6 +384,9 @@ public class TaggingActivity extends Activity {
                 // Increase count
                 mCurveballCount.setText(Integer.toString(++eventCurveballCount));
 
+                // Increase pitcher count
+                ++pitcherCurveballCount;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -352,6 +398,9 @@ public class TaggingActivity extends Activity {
                 // Increase count
                 mSliderCount.setText(Integer.toString(++eventSliderCount));
 
+                // Increase pitcher count
+                ++pitcherSliderCount;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -362,6 +411,9 @@ public class TaggingActivity extends Activity {
             public void onClick(View view) {
                 // Increase count
                 mOtherCount.setText(Integer.toString(++eventOtherCount));
+
+                // Increase pitcher count
+                ++pitcherOtherCount;
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -429,9 +481,9 @@ public class TaggingActivity extends Activity {
 
                     // Send individual statistics to Firebase
                     sendPitcherStats(eventID, eventName, eventDate, 0, 0, pitcherPitchCount, pitcherStrikesCount,
-                            pitcherBallsCount, count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
-                            count_R3C1, count_R3C2, count_R3C3, pitcherFastballCount, pitcherChangeupCount,
-                            pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
+                            pitcherBallsCount, pitcherCount_R1C1, pitcherCount_R1C2, pitcherCount_R1C3, pitcherCount_R2C1,
+                            pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
+                            pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
 
 
                 }
@@ -447,8 +499,8 @@ public class TaggingActivity extends Activity {
 
                 // Send stats
                 sendGameStats(eventID, eventName, eventDate, 0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
-                        count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
-                        count_R3C1, count_R3C2, count_R3C3, eventFastballCount, eventChangeupCount,
+                        eventCount_R1C1, eventCount_R1C2, eventCount_R1C3, eventCount_R2C1, eventCount_R2C2, eventCount_R2C3,
+                        eventCount_R3C1, eventCount_R3C2, eventCount_R3C3, eventFastballCount, eventChangeupCount,
                         eventCurveballCount, eventSliderCount, eventOtherCount);
             }
         });

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -6,17 +6,24 @@ import android.content.Intent;
 import android.nfc.Tag;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.EditText;
+import android.widget.Spinner;
 import android.widget.TextView;
 
+import com.google.firebase.database.DataSnapshot;
+import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
+import com.google.firebase.database.ValueEventListener;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.List;
 
 import pitcherseye.pitcherseye.Objects.EventStats;
 import pitcherseye.pitcherseye.Objects.PitcherStats;
@@ -45,9 +52,6 @@ public class TaggingActivity extends Activity {
     EditText mEventName;
     EditText mPitcherFirst;
     EditText mPitcherLast;
-    TextView mPitchCount;
-    TextView mTextStrikes;
-    TextView mTextBalls;
 
     // Request Code
     int REQUEST_CODE_CALCULATE = 0;
@@ -57,6 +61,7 @@ public class TaggingActivity extends Activity {
     String pitcherFirstName;
     String pitcherLastName;
     String pitcherName;
+    Spinner mSpinnerPitchers;
     Boolean pitcherSet = false;
     Boolean eventSet = false;
     Boolean isGame;
@@ -194,6 +199,31 @@ public class TaggingActivity extends Activity {
         mPitcherCurveballCount = (TextView) findViewById(R.id.txt_pitcher_curveball_count);
         mPitcherSliderCount = (TextView) findViewById(R.id.txt_pitcher_slider_count);
         mPitcherOtherCount = (TextView) findViewById(R.id.txt_pitcher_other_count);
+
+        // Instantiate and load pitchers into spinner
+        mDatabase.child("users").addValueEventListener(new ValueEventListener() {
+            @Override
+            public void onDataChange(DataSnapshot dataSnapshot) {
+                final List<String> pitchers = new ArrayList<String>();
+
+                for (DataSnapshot areaSnapshot: dataSnapshot.getChildren()) {
+                    String pitcherFName = areaSnapshot.child("fname").getValue(String.class);
+                    String pitcherLName = areaSnapshot.child("lname").getValue(String.class);
+                    String pitcherFullName = pitcherFName + " " + pitcherLName;
+                    pitchers.add(pitcherFullName);
+                }
+
+                mSpinnerPitchers = (Spinner) findViewById(R.id.spin_pitcher_names);
+                ArrayAdapter<String> pitchersAdapter = new ArrayAdapter<String>(TaggingActivity.this, android.R.layout.simple_spinner_item, pitchers);
+                pitchersAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                mSpinnerPitchers.setAdapter(pitchersAdapter);
+            }
+
+            @Override
+            public void onCancelled(DatabaseError databaseError) {
+
+            }
+        });
 
         // Check to see if there is input for the event and the pitcher
         // If there isn't, don't allow the user to tag the games
@@ -612,7 +642,7 @@ public class TaggingActivity extends Activity {
                     pitcherSet = false;
                 }
                 enableTagging(eventSet, pitcherSet);
-                mUndo.setEnabled(false);
+                mUndo.setEnabled(false  );
             }
         });
 

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -612,6 +612,7 @@ public class TaggingActivity extends Activity {
                     pitcherSet = false;
                 }
                 enableTagging(eventSet, pitcherSet);
+                mUndo.setEnabled(false);
             }
         });
 
@@ -718,6 +719,9 @@ public class TaggingActivity extends Activity {
                     mEventOtherCount.setText(Integer.toString(--eventOtherCount));
                     mPitcherOtherCount.setText(Integer.toString(--pitcherOtherCount));
                 }
+                undoPitchRegion = 0;
+                undoPitchType = 0;
+                mUndo.setEnabled(false);
             }
         });
 

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -18,6 +18,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 
 import pitcherseye.pitcherseye.Objects.EventStats;
+import pitcherseye.pitcherseye.Objects.PitcherStats;
 import pitcherseye.pitcherseye.R;
 import pitcherseye.pitcherseye.Utilities;
 
@@ -45,13 +46,6 @@ public class TaggingActivity extends Activity {
     TextView mPitchCount;
     TextView mTextStrikes;
     TextView mTextBalls;
-    TextView mTextR1C3;
-    TextView mTextR2C1;
-    TextView mTextR2C2;
-    TextView mTextR2C3;
-    TextView mTextR3C1;
-    TextView mTextR3C2;
-    TextView mTextR3C3;
 
     // Request Code
     int REQUEST_CODE_CALCULATE = 0;
@@ -80,17 +74,28 @@ public class TaggingActivity extends Activity {
     TextView mSliderCount;
     TextView mOtherCount;
 
-    // Statistic counts
-    int pitchCounter = 0;
-    int strikes = 0;
-    int balls = 0;
-
     // Events count
-    int fastballCount = 0;
-    int changeupCount = 0;
-    int curveballCount = 0;
-    int sliderCount = 0;
-    int otherCount = 0;
+    int eventPitchCount = 0;
+    int eventStrikesCount = 0;
+    int eventBallsCount = 0;
+
+    int eventFastballCount = 0;
+    int eventChangeupCount = 0;
+    int eventCurveballCount = 0;
+    int eventSliderCount = 0;
+    int eventOtherCount = 0;
+
+    // Individual Pitchers count
+
+    int pitcherPitchCount = 0;
+    int pitcherStrikesCount = 0;
+    int pitcherBallsCount = 0;
+
+    int pitcherFastballCount = 0;
+    int pitcherChangeupCount = 0;
+    int pitcherCurveballCount = 0;
+    int pitcherSliderCount = 0;
+    int pitcherOtherCount = 0;
 
     // Location counts
     int count_R1C1 = 0;
@@ -164,10 +169,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase pitch count
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R1C1;
@@ -181,10 +186,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase pitch count
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
-                // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                // Increase eventStrikes
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R1C2;
@@ -197,10 +202,10 @@ public class TaggingActivity extends Activity {
         mR1C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R1C3;
@@ -213,10 +218,10 @@ public class TaggingActivity extends Activity {
         mR2C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R2C1;
@@ -229,10 +234,10 @@ public class TaggingActivity extends Activity {
         mR2C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R2C2;
@@ -245,10 +250,10 @@ public class TaggingActivity extends Activity {
         mR2C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R2C3;
@@ -262,10 +267,10 @@ public class TaggingActivity extends Activity {
         mR3C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R3C1;
@@ -278,10 +283,10 @@ public class TaggingActivity extends Activity {
         mR3C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R3C2;
@@ -294,10 +299,10 @@ public class TaggingActivity extends Activity {
         mR3C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++pitchCounter));
+                mPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++strikes));
+                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
 
                 // Increase region count
                 ++count_R3C3;
@@ -312,7 +317,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mFastballCount.setText(Integer.toString(++fastballCount));
+                mFastballCount.setText(Integer.toString(++eventFastballCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -323,7 +328,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mChangeupCount.setText(Integer.toString(++changeupCount));
+                mChangeupCount.setText(Integer.toString(++eventChangeupCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -334,7 +339,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mCurveballCount.setText(Integer.toString(++curveballCount));
+                mCurveballCount.setText(Integer.toString(++eventCurveballCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -345,7 +350,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mSliderCount.setText(Integer.toString(++sliderCount));
+                mSliderCount.setText(Integer.toString(++eventSliderCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -356,7 +361,7 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mOtherCount.setText(Integer.toString(++otherCount));
+                mOtherCount.setText(Integer.toString(++eventOtherCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -419,9 +424,14 @@ public class TaggingActivity extends Activity {
 
                     pitcherSet = false;
 
-                    // TODO: Need to send statistics to Firebase for the previous pitcher
-                    // Send the pitcher's stats on change
-                    // Need to create variables for individual pitching statistics and not game stats
+                    // Generate unique ID
+                    String eventID = Utilities.createRandomHex(6);
+
+                    // Send individual statistics to Firebase
+                    sendPitcherStats(eventID, eventName, eventDate, 0, 0, pitcherPitchCount, pitcherStrikesCount,
+                            pitcherBallsCount, count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
+                            count_R3C1, count_R3C2, count_R3C3, pitcherFastballCount, pitcherChangeupCount,
+                            pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
 
 
                 }
@@ -436,10 +446,10 @@ public class TaggingActivity extends Activity {
                 String eventID = Utilities.createRandomHex(6);
 
                 // Send stats
-                sendGameStats(eventID, eventName, eventDate, 0, 0, pitchCounter, strikes, balls,
+                sendGameStats(eventID, eventName, eventDate, 0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
                         count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
-                        count_R3C1, count_R3C2, count_R3C3, fastballCount, changeupCount,
-                        curveballCount, sliderCount, otherCount);
+                        count_R3C1, count_R3C2, count_R3C3, eventFastballCount, eventChangeupCount,
+                        eventCurveballCount, eventSliderCount, eventOtherCount);
             }
         });
 
@@ -540,15 +550,29 @@ public class TaggingActivity extends Activity {
 
     private void sendGameStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
-                               int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
-                               int changeupCount, int curveballCount, int sliderCount, int otherCount) {
+                               int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int eventFastballCount,
+                               int eventChangeupCount, int eventCurveballCount, int eventSliderCount, int eventOtherCount) {
         // Defaulting some statistics to 0 until we establish further IDs
-        EventStats gameStats = new EventStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
+        EventStats eventStats = new EventStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
+                R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
+                R2C3Count, R3C1Count, R3C2Count, R3C3Count, eventFastballCount,
+                eventChangeupCount, eventCurveballCount, eventSliderCount, eventOtherCount);
+
+        mDatabase.child("eventStats").child(eventID).setValue(eventStats);
+    }
+
+    // Could have kept this in sendGameStats, but wanted an individual method in case we decide to change this
+    private void sendPitcherStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+                                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
+                                  int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
+                                  int changeupCount, int curveballCount, int sliderCount, int otherCount) {
+
+        PitcherStats pitcherStats = new PitcherStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count, fastballCount,
                 changeupCount, curveballCount, sliderCount, otherCount);
 
-        mDatabase.child("eventStats").child(eventID).setValue(gameStats);
+        mDatabase.child("pitcherStats").child(eventID).setValue(pitcherStats);
     }
 
     public static Intent newIntent(Context packageContext) {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -64,13 +64,33 @@ public class TaggingActivity extends Activity {
     Boolean eventSet = false;
     Boolean isGame;
     Boolean isHome;
+    Boolean locationSelected = false;
     DateFormat df = new SimpleDateFormat("yyyy-MM-dd");
     String eventDate = df.format(Calendar.getInstance().getTime());
+
+    // Results
+    Button mFastball;
+    Button mChangeup;
+    Button mCurveball;
+    Button mSlider;
+    Button mOther;
+    TextView mFastballCount;
+    TextView mChangeupCount;
+    TextView mCurveballCount;
+    TextView mSliderCount;
+    TextView mOtherCount;
 
     // Statistic counts
     int pitchCounter = 0;
     int strikes = 0;
     int balls = 0;
+
+    // Events count
+    int fastballCount = 0;
+    int changeupCount = 0;
+    int curveballCount = 0;
+    int sliderCount = 0;
+    int otherCount = 0;
 
     // Location counts
     int count_R1C1 = 0;
@@ -102,6 +122,11 @@ public class TaggingActivity extends Activity {
         mR3C1 = (Button) findViewById(R.id.btnR3C1);
         mR3C2 = (Button) findViewById(R.id.btnR3C2);
         mR3C3 = (Button) findViewById(R.id.btnR3C3);
+        mFastball = (Button) findViewById(R.id.btn_result_fastball);
+        mChangeup = (Button) findViewById(R.id.btn_result_changeup);
+        mCurveball = (Button) findViewById(R.id.btn_result_curve);
+        mSlider = (Button) findViewById(R.id.btn_result_slider);
+        mOther = (Button) findViewById(R.id.btn_result_other);
         mFinishGame = (Button) findViewById(R.id.btn_finish_game);
         mConfirmEvent = (Button) findViewById(R.id.btn_event_confirm);
         mConfirmPitcher = (Button) findViewById(R.id.btn_event_pitcher);
@@ -119,19 +144,20 @@ public class TaggingActivity extends Activity {
         mPitchCount = (TextView) findViewById(R.id.txt_pitch_count_counter);
         mTextStrikes = (TextView) findViewById(R.id.txt_strikes_counter);
         mTextBalls = (TextView) findViewById(R.id.txt_balls_counter);
-        mTextR1C3 = (TextView) findViewById(R.id.txt_R1C3);
-        mTextR2C1 = (TextView) findViewById(R.id.txt_R2C1);
-        mTextR2C2 = (TextView) findViewById(R.id.txt_R2C2);
-        mTextR2C3 = (TextView) findViewById(R.id.txt_R2C3);
-        mTextR3C1 = (TextView) findViewById(R.id.txt_R3C1);
-        mTextR3C2 = (TextView) findViewById(R.id.txt_R3C2);
-        mTextR3C3 = (TextView) findViewById(R.id.txt_R3C3);
+        mFastballCount = (TextView) findViewById(R.id.txt_fastball_counter);
+        mChangeupCount = (TextView) findViewById(R.id.txt_changeup_counter);
+        mCurveballCount = (TextView) findViewById(R.id.txt_curveball_counter);
+        mSliderCount = (TextView) findViewById(R.id.txt_slider_counter);
+        mOtherCount = (TextView) findViewById(R.id.txt_other_counter);
 
 
         // Check to see if there is input for the event and the pitcher
         // If there isn't, don't allow the user to tag the games
         // This should disable buttons on start
+
+        // Also ensure that the workflow is set correctly on startup
         enableTagging(eventSet, pitcherSet);
+        disableResults();
 
         // Needs refactoring eventually
         mR1C1.setOnClickListener(new View.OnClickListener() {
@@ -145,6 +171,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R1C1;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
@@ -159,13 +188,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R1C2;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR1C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR1C3.setText(Integer.toString(count_R1C3));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -173,13 +204,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R1C3;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR2C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR2C1.setText(Integer.toString(count_R2C1));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -187,13 +220,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R2C1;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR2C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR2C2.setText(Integer.toString(count_R2C2));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -201,13 +236,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R2C2;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR2C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR2C3.setText(Integer.toString(count_R2C3));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -215,13 +252,16 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R2C3;
+
+                // Notify that we've selected the location for the workflow
+                //locationSelected = false;
+                enableTagging(locationSelected  = true);
             }
         });
 
         mR3C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR3C1.setText(Integer.toString(count_R3C1));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -229,13 +269,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R3C1;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR3C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR3C2.setText(Integer.toString(count_R3C2));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -243,13 +285,15 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R3C2;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
             }
         });
 
         mR3C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mTextR3C3.setText(Integer.toString(count_R3C3));
                 mPitchCount.setText(Integer.toString(++pitchCounter));
 
                 // Increase strikes
@@ -257,6 +301,65 @@ public class TaggingActivity extends Activity {
 
                 // Increase region count
                 ++count_R3C3;
+
+                // Notify that we've selected the location for the workflow
+                enableTagging(locationSelected = true);
+            }
+        });
+
+        // Result events
+        mFastball.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Increase count
+                mFastballCount.setText(Integer.toString(++fastballCount));
+
+                // Reenable grid
+                enableTagging(locationSelected = false);
+            }
+        });
+
+        mChangeup.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Increase count
+                mChangeupCount.setText(Integer.toString(++changeupCount));
+
+                // Reenable grid
+                enableTagging(locationSelected = false);
+            }
+        });
+
+        mCurveball.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Increase count
+                mCurveballCount.setText(Integer.toString(++curveballCount));
+
+                // Reenable grid
+                enableTagging(locationSelected = false);
+            }
+        });
+
+        mSlider.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Increase count
+                mSliderCount.setText(Integer.toString(++sliderCount));
+
+                // Reenable grid
+                enableTagging(locationSelected = false);
+            }
+        });
+
+        mOther.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Increase count
+                mOtherCount.setText(Integer.toString(++otherCount));
+
+                // Reenable grid
+                enableTagging(locationSelected = false);
             }
         });
 
@@ -335,12 +438,14 @@ public class TaggingActivity extends Activity {
                 // Send stats
                 sendGameStats(eventID, eventName, eventDate, 0, 0, pitchCounter, strikes, balls,
                         count_R1C1, count_R1C2, count_R1C3, count_R2C1, count_R2C2, count_R2C3,
-                        count_R3C1, count_R3C2, count_R3C3);
+                        count_R3C1, count_R3C2, count_R3C3, fastballCount, changeupCount,
+                        curveballCount, sliderCount, otherCount);
             }
         });
 
     }
 
+    // We'll call this when checking to see if the event name and pitchers are set
     private void enableTagging(Boolean eventSet, Boolean pitcherSet) {
         if (eventSet && pitcherSet) {
             mR1C1.setEnabled(true);
@@ -365,6 +470,57 @@ public class TaggingActivity extends Activity {
         }
     }
 
+    // Wrapper method to enable tagging during the result workflow
+    private void enableTagging(Boolean locationSelected) {
+        if (locationSelected) {
+            mR1C1.setEnabled(false);
+            mR1C2.setEnabled(false);
+            mR1C3.setEnabled(false);
+            mR2C1.setEnabled(false);
+            mR2C2.setEnabled(false);
+            mR2C3.setEnabled(false);
+            mR3C1.setEnabled(false);
+            mR3C2.setEnabled(false);
+            mR3C3.setEnabled(false);
+
+            mFastball.setEnabled(true);
+            mChangeup.setEnabled(true);
+            mCurveball.setEnabled(true);
+            mSlider.setEnabled(true);
+            mOther.setEnabled(true);
+
+            mConfirmEvent.setEnabled(false);
+            mConfirmPitcher.setEnabled(false);
+        } else {
+            mR1C1.setEnabled(true);
+            mR1C2.setEnabled(true);
+            mR1C3.setEnabled(true);
+            mR2C1.setEnabled(true);
+            mR2C2.setEnabled(true);
+            mR2C3.setEnabled(true);
+            mR3C1.setEnabled(true);
+            mR3C2.setEnabled(true);
+            mR3C3.setEnabled(true);
+
+            mFastball.setEnabled(false);
+            mChangeup.setEnabled(false);
+            mCurveball.setEnabled(false);
+            mSlider.setEnabled(false);
+            mOther.setEnabled(false);
+
+            mConfirmEvent.setEnabled(true);
+            mConfirmPitcher.setEnabled(true);
+        }
+    }
+
+    private void disableResults() {
+        mFastball.setEnabled(false);
+        mChangeup.setEnabled(false);
+        mCurveball.setEnabled(false);
+        mSlider.setEnabled(false);
+        mOther.setEnabled(false);
+    }
+
     private void saveEventInfo() {
         eventName = mEventName.getText().toString().trim();
         if (!mEventType.isChecked()) {
@@ -384,11 +540,13 @@ public class TaggingActivity extends Activity {
 
     private void sendGameStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
-                               int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
+                               int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
+                               int changeupCount, int curveballCount, int sliderCount, int otherCount) {
         // Defaulting some statistics to 0 until we establish further IDs
         EventStats gameStats = new EventStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
-                R2C3Count, R3C1Count, R3C2Count, R3C3Count);
+                R2C3Count, R3C1Count, R3C2Count, R3C3Count, fastballCount,
+                changeupCount, curveballCount, sliderCount, otherCount);
 
         mDatabase.child("eventStats").child(eventID).setValue(gameStats);
     }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -16,7 +16,7 @@ import android.widget.TextView;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
 
-import pitcherseye.pitcherseye.Objects.PitchingStats;
+import pitcherseye.pitcherseye.Objects.GameStats;
 import pitcherseye.pitcherseye.R;
 
 public class TaggingActivity extends Activity {
@@ -305,6 +305,7 @@ public class TaggingActivity extends Activity {
                 } else {
                     // If there IS a pitcher set and the "Change Pitcher" button is selected,
                     // update the fields to allow the user to enter a new pitcher
+                    // Also sends the pitcher's stats after changing pitchers
                     mPitcherFirst.setEnabled(true);
                     mPitcherLast.setEnabled(true);
 
@@ -313,6 +314,10 @@ public class TaggingActivity extends Activity {
                     pitcherSet = false;
 
                     // TODO: Need to send statistics to Firebase for the previous pitcher
+                    // Send the pitcher's stats on change
+                    // Need to create variables for individual pitching statistics and not game stats
+
+
                 }
                 enableTagging(eventSet, pitcherSet);
             }
@@ -374,12 +379,12 @@ public class TaggingActivity extends Activity {
     private void sendGameStats(int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
-        // Defaulting to 0 until we establish further IDs
-        PitchingStats pitchingStats = new PitchingStats(gameID, playerID, teamID, pitchCount, strikeCount, ballCount,
+        // Defaulting some statistics to 0 until we establish further IDs
+        GameStats gameStats = new GameStats(gameID, playerID, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count);
 
-        mDatabase.child("pitchingStats").child(Integer.toString(gameID)).setValue(pitchingStats);
+        mDatabase.child("pitchingStats").child(Integer.toString(gameID)).setValue(gameStats);
     }
 
     public static Intent newIntent(Context packageContext) {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -12,6 +12,7 @@ import android.widget.CheckBox;
 import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
@@ -178,8 +179,8 @@ public class TaggingActivity extends Activity {
 
         // Instantiate EditTexts
         mEventName = (EditText) findViewById(R.id.edt_txt_event_name_entry);
-        mPitcherFirst = (EditText) findViewById(R.id.edt_txt_event_pitcher_first_name);
-        mPitcherLast = (EditText) findViewById(R.id.edt_txt_event_pitcher_last_name);
+        //mPitcherFirst = (EditText) findViewById(R.id.edt_txt_event_pitcher_first_name);
+        //mPitcherLast = (EditText) findViewById(R.id.edt_txt_event_pitcher_last_name);
 
         // Instantiate TextViews
         mEventPitchCount = (TextView) findViewById(R.id.txt_event_pitch_count);
@@ -205,11 +206,12 @@ public class TaggingActivity extends Activity {
             @Override
             public void onDataChange(DataSnapshot dataSnapshot) {
                 final List<String> pitchers = new ArrayList<String>();
-
+                pitchers.add(" ");
                 for (DataSnapshot areaSnapshot: dataSnapshot.getChildren()) {
                     String pitcherFName = areaSnapshot.child("fname").getValue(String.class);
                     String pitcherLName = areaSnapshot.child("lname").getValue(String.class);
                     String pitcherFullName = pitcherFName + " " + pitcherLName;
+                    // Add empty space for the start
                     pitchers.add(pitcherFullName);
                 }
 
@@ -232,6 +234,7 @@ public class TaggingActivity extends Activity {
         // Also ensure that the workflow is set correctly on startup
         enableTagging(eventSet, pitcherSet);
         mUndo.setEnabled(false);
+        mFinishGame.setEnabled(false);
         disableResults();
 
         // Needs refactoring eventually
@@ -612,21 +615,25 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // If there isn't a pitcher set yet, save the input
-                if (!pitcherSet) {
+                if (!pitcherSet && mSpinnerPitchers.getSelectedItem().toString() != " ") {
                     savePitcherInfo();
 
                     // Disable EditTexts
-                    mPitcherFirst.setEnabled(false);
-                    mPitcherLast.setEnabled(false);
+                    //mPitcherFirst.setEnabled(false);
+                    //mPitcherLast.setEnabled(false);
+                    mSpinnerPitchers.setEnabled(false);
 
                     // Change button text
                     mConfirmPitcher.setText("Change Pitcher");
+                } else if (mSpinnerPitchers.getSelectedItem().toString() == " ") {
+                    Toast.makeText(getApplicationContext(), "Enter a pitcher to start session", Toast.LENGTH_SHORT).show();
                 } else {
                     // If there IS a pitcher set and the "Change Pitcher" button is selected,
                     // update the fields to allow the user to enter a new pitcher
                     // Also sends the pitcher's stats after changing pitchers
-                    mPitcherFirst.setEnabled(true);
-                    mPitcherLast.setEnabled(true);
+                    //mPitcherFirst.setEnabled(true);
+                    //mPitcherLast.setEnabled(true);
+                    mSpinnerPitchers.setEnabled(true);
 
                     String eventID = Utilities.createRandomHex(6);
 
@@ -642,21 +649,15 @@ public class TaggingActivity extends Activity {
                     pitcherSet = false;
                 }
                 enableTagging(eventSet, pitcherSet);
-                mUndo.setEnabled(false  );
+                mUndo.setEnabled(false);
+                mFinishGame.setEnabled(false);
             }
         });
 
         mUndo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                // Let's see if we can implement this logic
-//                for (int i = 0; i < 15; i++) {
-//                    if (i == undoPitchRegion) {
-//
-//                    }
-//                }
-
-                // Ouch
+                // TODO needs refactoring
                 if (1 == undoPitchRegion) {
                     mEventPitchCount.setText(Integer.toString(--eventPitchCount));
                     mEventStrikes.setText(Integer.toString(--eventStrikesCount));
@@ -752,6 +753,7 @@ public class TaggingActivity extends Activity {
                 undoPitchRegion = 0;
                 undoPitchType = 0;
                 mUndo.setEnabled(false);
+                mFinishGame.setEnabled(false);
             }
         });
 
@@ -790,6 +792,7 @@ public class TaggingActivity extends Activity {
             mR3C2.setEnabled(true);
             mR3C3.setEnabled(true);
             mUndo.setEnabled(true);
+            mFinishGame.setEnabled(true);
         } else {
             mR1C1.setEnabled(false);
             mR1C2.setEnabled(false);
@@ -801,6 +804,7 @@ public class TaggingActivity extends Activity {
             mR3C2.setEnabled(false);
             mR3C3.setEnabled(false);
             mUndo.setEnabled(false);
+            mFinishGame.setEnabled(false);
         }
     }
 
@@ -827,6 +831,7 @@ public class TaggingActivity extends Activity {
             mConfirmPitcher.setEnabled(false);
 
             mUndo.setEnabled(false);
+            mFinishGame.setEnabled(false);
         } else {
             mR1C1.setEnabled(true);
             mR1C2.setEnabled(true);
@@ -848,6 +853,7 @@ public class TaggingActivity extends Activity {
             mConfirmPitcher.setEnabled(true);
 
             mUndo.setEnabled(true);
+            mFinishGame.setEnabled(true);
         }
     }
 
@@ -871,9 +877,10 @@ public class TaggingActivity extends Activity {
     }
 
     private void savePitcherInfo() {
-        pitcherFirstName = mPitcherFirst.getText().toString().trim();
-        pitcherLastName = mPitcherLast.getText().toString().trim();
-        pitcherName = pitcherFirstName + " " + pitcherLastName;
+        //pitcherFirstName = mPitcherFirst.getText().toString().trim();
+        //pitcherLastName = mPitcherLast.getText().toString().trim();
+        //pitcherName = pitcherFirstName + " " + pitcherLastName;
+        pitcherName = mSpinnerPitchers.getSelectedItem().toString();
         pitcherSet = true;
     }
 

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -36,6 +36,7 @@ public class TaggingActivity extends Activity {
     Button mR3C2;
     Button mR3C3;
     Button mFinishGame;
+    Button mUndo;
     Button mConfirmEvent;
     Button mConfirmPitcher;
     CheckBox mEventType;
@@ -102,7 +103,6 @@ public class TaggingActivity extends Activity {
     int eventOtherCount = 0;
 
     // Individual Pitchers count
-
     int pitcherPitchCount = 0;
     int pitcherStrikesCount = 0;
     int pitcherBallsCount = 0;
@@ -134,6 +134,10 @@ public class TaggingActivity extends Activity {
     int pitcherCount_R3C2 = 0;
     int pitcherCount_R3C3 = 0;
 
+    // Undo
+    int undoPitchRegion = 0;
+    int undoPitchType = 0;
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -159,6 +163,7 @@ public class TaggingActivity extends Activity {
         mSlider = (Button) findViewById(R.id.btn_result_slider);
         mOther = (Button) findViewById(R.id.btn_result_other);
         mFinishGame = (Button) findViewById(R.id.btn_finish_game);
+        mUndo = (Button) findViewById(R.id.btn_undo);
         mConfirmEvent = (Button) findViewById(R.id.btn_event_confirm);
         mConfirmPitcher = (Button) findViewById(R.id.btn_event_pitcher);
 
@@ -196,6 +201,7 @@ public class TaggingActivity extends Activity {
 
         // Also ensure that the workflow is set correctly on startup
         enableTagging(eventSet, pitcherSet);
+        mUndo.setEnabled(false);
         disableResults();
 
         // Needs refactoring eventually
@@ -219,6 +225,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher region count
                 ++pitcherCount_R1C1;
+
+                // Keep track of previous pitch
+                undoPitchRegion = 1;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -246,6 +255,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher region count
                 ++pitcherCount_R1C2;
 
+                // Keep track of previous pitch
+                undoPitchRegion = 2;
+
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
             }
@@ -270,6 +282,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher region count
                 ++pitcherCount_R1C3;
+
+                // Keep track of previous pitch
+                undoPitchRegion = 3;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -296,6 +311,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher region count
                 ++pitcherCount_R2C1;
 
+                // Keep track of previous pitch
+                undoPitchRegion = 4;
+
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
             }
@@ -321,6 +339,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher region count
                 ++pitcherCount_R2C2;
 
+                // Keep track of previous pitch
+                undoPitchRegion = 5;
+
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
             }
@@ -345,6 +366,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher region count
                 ++pitcherCount_R2C3;
+
+                // Keep track of previous pitch
+                undoPitchRegion = 6;
 
                 // Notify that we've selected the location for the workflow
                 //locationSelected = false;
@@ -372,6 +396,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher region count
                 ++pitcherCount_R3C1;
 
+                // Keep track of previous pitch
+                undoPitchRegion = 7;
+
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
             }
@@ -396,6 +423,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher region count
                 ++pitcherCount_R3C2;
+
+                // Keep track of previous pitch
+                undoPitchRegion = 8;
 
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
@@ -422,6 +452,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher region count
                 ++pitcherCount_R3C3;
 
+                // Keep track of previous pitch
+                undoPitchRegion = 9;
+
                 // Notify that we've selected the location for the workflow
                 enableTagging(locationSelected = true);
             }
@@ -437,6 +470,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher count
                 mPitcherFastballCount.setText(Integer.toString(++pitcherFastballCount));
 
+                // Keep track of previous pitch
+                undoPitchType = 10;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -450,6 +486,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher count
                 mPitcherChangeupCount.setText(Integer.toString(++pitcherChangeupCount));
+
+                // Keep track of previous pitch
+                undoPitchType = 11;
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -465,6 +504,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher count
                 mPitcherCurveballCount.setText(Integer.toString(++pitcherCurveballCount));
 
+                // Keep track of previous pitch
+                undoPitchType = 12;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -479,6 +521,9 @@ public class TaggingActivity extends Activity {
                 // Increase pitcher count
                 mPitcherSliderCount.setText(Integer.toString(++pitcherSliderCount));
 
+                // Keep track of previous pitch
+                undoPitchType = 13;
+
                 // Reenable grid
                 enableTagging(locationSelected = false);
             }
@@ -492,6 +537,9 @@ public class TaggingActivity extends Activity {
 
                 // Increase pitcher count
                 mPitcherOtherCount.setText(Integer.toString(++pitcherOtherCount));
+
+                // Keep track of previous pitch
+                undoPitchType = 14;
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -567,6 +615,112 @@ public class TaggingActivity extends Activity {
             }
         });
 
+        mUndo.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                // Let's see if we can implement this logic
+//                for (int i = 0; i < 15; i++) {
+//                    if (i == undoPitchRegion) {
+//
+//                    }
+//                }
+
+                // Ouch
+                if (1 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R1C1;
+                    --pitcherCount_R1C1;
+                }
+                if (2 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R1C2;
+                    --pitcherCount_R1C2;
+                }
+                if (3 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R1C3;
+                    --pitcherCount_R1C3;
+                }
+                if (4 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R2C1;
+                    --pitcherCount_R2C1;
+                }
+                if (5 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R2C2;
+                    --pitcherCount_R2C2;
+                }
+                if (6 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R2C3;
+                    --pitcherCount_R2C3;
+                }
+                if (7 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R3C1;
+                    --pitcherCount_R3C1;
+                }
+                if (8 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R3C2;
+                    --pitcherCount_R3C2;
+                }
+                if (9 == undoPitchRegion) {
+                    mEventPitchCount.setText(Integer.toString(--eventPitchCount));
+                    mEventStrikes.setText(Integer.toString(--eventStrikesCount));
+                    mPitcherPitchCount.setText(Integer.toString(--pitcherPitchCount));
+                    mPitcherStrikes.setText(Integer.toString(--pitcherStrikesCount));
+                    --eventCount_R3C2;
+                    --pitcherCount_R1C1;
+                }
+                if (10 == undoPitchType) {
+                    mEventFastballCount.setText(Integer.toString(--eventFastballCount));
+                    mPitcherFastballCount.setText(Integer.toString(--pitcherFastballCount));
+                }
+                if (11 == undoPitchType) {
+                    mEventChangeupCount.setText(Integer.toString(--eventChangeupCount));
+                    mPitcherChangeupCount.setText(Integer.toString(--pitcherChangeupCount));
+                }
+                if (12 == undoPitchType) {
+                    mEventCurveballCount.setText(Integer.toString(--eventCurveballCount));
+                    mPitcherCurveballCount.setText(Integer.toString(--pitcherCurveballCount));
+                }
+                if (13 == undoPitchType) {
+                    mEventSliderCount.setText(Integer.toString(--eventSliderCount));
+                    mPitcherSliderCount.setText(Integer.toString(--pitcherSliderCount));
+                }
+                if (14 == undoPitchType) {
+                    mEventOtherCount.setText(Integer.toString(--eventOtherCount));
+                    mPitcherOtherCount.setText(Integer.toString(--pitcherOtherCount));
+                }
+            }
+        });
+
         mFinishGame.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -587,7 +741,6 @@ public class TaggingActivity extends Activity {
                         pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
             }
         });
-
     }
 
     // We'll call this when checking to see if the event name and pitchers are set
@@ -602,6 +755,7 @@ public class TaggingActivity extends Activity {
             mR3C1.setEnabled(true);
             mR3C2.setEnabled(true);
             mR3C3.setEnabled(true);
+            mUndo.setEnabled(true);
         } else {
             mR1C1.setEnabled(false);
             mR1C2.setEnabled(false);
@@ -612,6 +766,7 @@ public class TaggingActivity extends Activity {
             mR3C1.setEnabled(false);
             mR3C2.setEnabled(false);
             mR3C3.setEnabled(false);
+            mUndo.setEnabled(false);
         }
     }
 
@@ -636,6 +791,8 @@ public class TaggingActivity extends Activity {
 
             mConfirmEvent.setEnabled(false);
             mConfirmPitcher.setEnabled(false);
+
+            mUndo.setEnabled(false);
         } else {
             mR1C1.setEnabled(true);
             mR1C2.setEnabled(true);
@@ -655,6 +812,8 @@ public class TaggingActivity extends Activity {
 
             mConfirmEvent.setEnabled(true);
             mConfirmPitcher.setEnabled(true);
+
+            mUndo.setEnabled(true);
         }
     }
 
@@ -740,5 +899,4 @@ public class TaggingActivity extends Activity {
         Intent i = new Intent(packageContext, TaggingActivity.class);
         return i;
     }
-
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -3,6 +3,7 @@ package pitcherseye.pitcherseye.Activities;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.nfc.Tag;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -54,6 +55,7 @@ public class TaggingActivity extends Activity {
     String eventName;
     String pitcherFirstName;
     String pitcherLastName;
+    String pitcherName;
     Boolean pitcherSet = false;
     Boolean eventSet = false;
     Boolean isGame;
@@ -68,11 +70,25 @@ public class TaggingActivity extends Activity {
     Button mCurveball;
     Button mSlider;
     Button mOther;
-    TextView mFastballCount;
-    TextView mChangeupCount;
-    TextView mCurveballCount;
-    TextView mSliderCount;
-    TextView mOtherCount;
+
+
+    TextView mEventFastballCount;
+    TextView mEventStrikes;
+    TextView mEventBalls;
+    TextView mEventPitchCount;
+    TextView mEventChangeupCount;
+    TextView mEventCurveballCount;
+    TextView mEventSliderCount;
+    TextView mEventOtherCount;
+
+    TextView mPitcherPitchCount;
+    TextView mPitcherStrikes;
+    TextView mPitcherBalls;
+    TextView mPitcherFastballCount;
+    TextView mPitcherChangeupCount;
+    TextView mPitcherCurveballCount;
+    TextView mPitcherSliderCount;
+    TextView mPitcherOtherCount;
 
     // Events count
     int eventPitchCount = 0;
@@ -156,15 +172,23 @@ public class TaggingActivity extends Activity {
         mPitcherLast = (EditText) findViewById(R.id.edt_txt_event_pitcher_last_name);
 
         // Instantiate TextViews
-        mPitchCount = (TextView) findViewById(R.id.txt_pitch_count_counter);
-        mTextStrikes = (TextView) findViewById(R.id.txt_strikes_counter);
-        mTextBalls = (TextView) findViewById(R.id.txt_balls_counter);
-        mFastballCount = (TextView) findViewById(R.id.txt_fastball_counter);
-        mChangeupCount = (TextView) findViewById(R.id.txt_changeup_counter);
-        mCurveballCount = (TextView) findViewById(R.id.txt_curveball_counter);
-        mSliderCount = (TextView) findViewById(R.id.txt_slider_counter);
-        mOtherCount = (TextView) findViewById(R.id.txt_other_counter);
+        mEventPitchCount = (TextView) findViewById(R.id.txt_event_pitch_count);
+        mEventStrikes = (TextView) findViewById(R.id.txt_event_strikes_count);
+        mEventBalls = (TextView) findViewById(R.id.txt_event_balls_count);
+        mEventFastballCount = (TextView) findViewById(R.id.txt_event_fastball_count);
+        mEventChangeupCount = (TextView) findViewById(R.id.txt_event_changeup_count);
+        mEventCurveballCount = (TextView) findViewById(R.id.txt_event_curveball_count);
+        mEventSliderCount = (TextView) findViewById(R.id.txt_event_slider_count);
+        mEventOtherCount = (TextView) findViewById(R.id.txt_event_other_count);
 
+        mPitcherPitchCount = (TextView) findViewById(R.id.txt_pitcher_pitch_count);
+        mPitcherStrikes = (TextView) findViewById(R.id.txt_pitcher_strikes_count);
+        mPitcherBalls = (TextView) findViewById(R.id.txt_pitcher_balls_count);
+        mPitcherFastballCount = (TextView) findViewById(R.id.txt_pitcher_fastball_count);
+        mPitcherChangeupCount = (TextView) findViewById(R.id.txt_pitcher_changeup_count);
+        mPitcherCurveballCount = (TextView) findViewById(R.id.txt_pitcher_curveball_count);
+        mPitcherSliderCount = (TextView) findViewById(R.id.txt_pitcher_slider_count);
+        mPitcherOtherCount = (TextView) findViewById(R.id.txt_pitcher_other_count);
 
         // Check to see if there is input for the event and the pitcher
         // If there isn't, don't allow the user to tag the games
@@ -179,10 +203,16 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase pitch count
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R1C1;
@@ -199,10 +229,16 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase pitch count
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase eventStrikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R1C2;
@@ -218,10 +254,16 @@ public class TaggingActivity extends Activity {
         mR1C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R1C3;
@@ -237,10 +279,16 @@ public class TaggingActivity extends Activity {
         mR2C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R2C1;
@@ -256,10 +304,16 @@ public class TaggingActivity extends Activity {
         mR2C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R2C2;
@@ -275,10 +329,16 @@ public class TaggingActivity extends Activity {
         mR2C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R2C3;
@@ -295,10 +355,16 @@ public class TaggingActivity extends Activity {
         mR3C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R3C1;
@@ -314,10 +380,16 @@ public class TaggingActivity extends Activity {
         mR3C2.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R3C2;
@@ -333,10 +405,16 @@ public class TaggingActivity extends Activity {
         mR3C3.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                mPitchCount.setText(Integer.toString(++eventPitchCount));
+                mEventPitchCount.setText(Integer.toString(++eventPitchCount));
 
                 // Increase strikes
-                mTextStrikes.setText(Integer.toString(++eventStrikesCount));
+                mEventStrikes.setText(Integer.toString(++eventStrikesCount));
+
+                // Increase pitcher count
+                mPitcherPitchCount.setText(Integer.toString(++pitcherPitchCount));
+
+                // Increase pitcher strikes
+                mPitcherStrikes.setText(Integer.toString(++pitcherStrikesCount));
 
                 // Increase region count
                 ++eventCount_R3C3;
@@ -354,10 +432,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mFastballCount.setText(Integer.toString(++eventFastballCount));
+                mEventFastballCount.setText(Integer.toString(++eventFastballCount));
 
                 // Increase pitcher count
-                ++pitcherFastballCount;
+                mPitcherFastballCount.setText(Integer.toString(++pitcherFastballCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -368,10 +446,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mChangeupCount.setText(Integer.toString(++eventChangeupCount));
+                mEventChangeupCount.setText(Integer.toString(++eventChangeupCount));
 
                 // Increase pitcher count
-                ++pitcherChangeupCount;
+                mPitcherChangeupCount.setText(Integer.toString(++pitcherChangeupCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -382,10 +460,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mCurveballCount.setText(Integer.toString(++eventCurveballCount));
+                mEventCurveballCount.setText(Integer.toString(++eventCurveballCount));
 
                 // Increase pitcher count
-                ++pitcherCurveballCount;
+                mPitcherCurveballCount.setText(Integer.toString(++pitcherCurveballCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -396,10 +474,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mSliderCount.setText(Integer.toString(++eventSliderCount));
+                mEventSliderCount.setText(Integer.toString(++eventSliderCount));
 
                 // Increase pitcher count
-                ++pitcherSliderCount;
+                mPitcherSliderCount.setText(Integer.toString(++pitcherSliderCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -410,10 +488,10 @@ public class TaggingActivity extends Activity {
             @Override
             public void onClick(View view) {
                 // Increase count
-                mOtherCount.setText(Integer.toString(++eventOtherCount));
+                mEventOtherCount.setText(Integer.toString(++eventOtherCount));
 
                 // Increase pitcher count
-                ++pitcherOtherCount;
+                mPitcherOtherCount.setText(Integer.toString(++pitcherOtherCount));
 
                 // Reenable grid
                 enableTagging(locationSelected = false);
@@ -472,20 +550,18 @@ public class TaggingActivity extends Activity {
                     mPitcherFirst.setEnabled(true);
                     mPitcherLast.setEnabled(true);
 
-                    mConfirmPitcher.setText("Confirm Pitcher");
-
-                    pitcherSet = false;
-
-                    // Generate unique ID
                     String eventID = Utilities.createRandomHex(6);
 
                     // Send individual statistics to Firebase
-                    sendPitcherStats(eventID, eventName, eventDate, 0, 0, pitcherPitchCount, pitcherStrikesCount,
+                    sendPitcherStats(eventID, eventName, eventDate, 0,
+                            pitcherName,0, pitcherPitchCount, pitcherStrikesCount,
                             pitcherBallsCount, pitcherCount_R1C1, pitcherCount_R1C2, pitcherCount_R1C3, pitcherCount_R2C1,
                             pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
                             pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
 
+                    mConfirmPitcher.setText("Confirm Pitcher");
 
+                    pitcherSet = false;
                 }
                 enableTagging(eventSet, pitcherSet);
             }
@@ -497,11 +573,18 @@ public class TaggingActivity extends Activity {
                 // Create the eventID and save with this event
                 String eventID = Utilities.createRandomHex(6);
 
-                // Send stats
-                sendGameStats(eventID, eventName, eventDate, 0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
+                // Send event stats
+                sendEventStats(eventID, eventName, eventDate, 0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
                         eventCount_R1C1, eventCount_R1C2, eventCount_R1C3, eventCount_R2C1, eventCount_R2C2, eventCount_R2C3,
                         eventCount_R3C1, eventCount_R3C2, eventCount_R3C3, eventFastballCount, eventChangeupCount,
                         eventCurveballCount, eventSliderCount, eventOtherCount);
+
+                // Send individual stats as well
+                sendPitcherStats(eventID, eventName, eventDate, 0,
+                        pitcherName,0, pitcherPitchCount, pitcherStrikesCount,
+                        pitcherBallsCount, pitcherCount_R1C1, pitcherCount_R1C2, pitcherCount_R1C3, pitcherCount_R2C1,
+                        pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
+                        pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
             }
         });
 
@@ -597,10 +680,11 @@ public class TaggingActivity extends Activity {
     private void savePitcherInfo() {
         pitcherFirstName = mPitcherFirst.getText().toString().trim();
         pitcherLastName = mPitcherLast.getText().toString().trim();
+        pitcherName = pitcherFirstName + " " + pitcherLastName;
         pitcherSet = true;
     }
 
-    private void sendGameStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    private void sendEventStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int eventFastballCount,
                                int eventChangeupCount, int eventCurveballCount, int eventSliderCount, int eventOtherCount) {
@@ -613,18 +697,43 @@ public class TaggingActivity extends Activity {
         mDatabase.child("eventStats").child(eventID).setValue(eventStats);
     }
 
-    // Could have kept this in sendGameStats, but wanted an individual method in case we decide to change this
-    private void sendPitcherStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    // Could have kept this in sendEventStats, but wanted an individual method in case we decide to change this
+    private void sendPitcherStats(String eventID, String eventName, String eventDate, int playerID, String pitcherName, int teamID, int pitchCount, int strikeCount, int ballCount,
                                   int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                                   int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
                                   int changeupCount, int curveballCount, int sliderCount, int otherCount) {
 
-        PitcherStats pitcherStats = new PitcherStats(eventID, eventName, eventDate, playerID, teamID, pitchCount, strikeCount, ballCount,
+        PitcherStats pitcherStats = new PitcherStats(eventID, eventName, eventDate, playerID,
+                pitcherName, teamID, pitchCount, strikeCount, ballCount,
                 R1C1Count, R1C2Count, R1C3Count, R2C1Count, R2C2Count,
                 R2C3Count, R3C1Count, R3C2Count, R3C3Count, fastballCount,
                 changeupCount, curveballCount, sliderCount, otherCount);
 
         mDatabase.child("pitcherStats").child(eventID).setValue(pitcherStats);
+
+        // Reset pitcher statistics
+        resetPitcherStats();
+    }
+
+    public void resetPitcherStats() {
+        pitcherCount_R1C1 = 0;
+        pitcherCount_R1C2 = 0;
+        pitcherCount_R1C3 = 0;
+        pitcherCount_R2C1 = 0;
+        pitcherCount_R2C2 = 0;
+        pitcherCount_R2C3 = 0;
+        pitcherCount_R3C1 = 0;
+        pitcherCount_R3C2 = 0;
+        pitcherCount_R3C3 = 0;
+
+        mPitcherPitchCount.setText(Integer.toString(pitcherPitchCount = 0));
+        mPitcherStrikes.setText(Integer.toString(pitcherStrikesCount = 0));
+        mPitcherBalls.setText(Integer.toString(pitcherBallsCount = 0));
+        mPitcherFastballCount.setText(Integer.toString(pitcherFastballCount = 0));
+        mPitcherChangeupCount.setText(Integer.toString(pitcherChangeupCount = 0));
+        mPitcherCurveballCount.setText(Integer.toString(pitcherCurveballCount = 0));
+        mPitcherSliderCount.setText(Integer.toString(pitcherSliderCount = 0));
+        mPitcherOtherCount.setText(Integer.toString(pitcherOtherCount = 0));
     }
 
     public static Intent newIntent(Context packageContext) {

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -179,8 +179,6 @@ public class TaggingActivity extends Activity {
 
         // Instantiate EditTexts
         mEventName = (EditText) findViewById(R.id.edt_txt_event_name_entry);
-        //mPitcherFirst = (EditText) findViewById(R.id.edt_txt_event_pitcher_first_name);
-        //mPitcherLast = (EditText) findViewById(R.id.edt_txt_event_pitcher_last_name);
 
         // Instantiate TextViews
         mEventPitchCount = (TextView) findViewById(R.id.txt_event_pitch_count);
@@ -230,14 +228,13 @@ public class TaggingActivity extends Activity {
         // Check to see if there is input for the event and the pitcher
         // If there isn't, don't allow the user to tag the games
         // This should disable buttons on start
-
         // Also ensure that the workflow is set correctly on startup
         enableTagging(eventSet, pitcherSet);
         mUndo.setEnabled(false);
         mFinishGame.setEnabled(false);
         disableResults();
 
-        // Needs refactoring eventually
+        // TODO Needs refactoring eventually
         mR1C1.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -631,8 +628,6 @@ public class TaggingActivity extends Activity {
                     // If there IS a pitcher set and the "Change Pitcher" button is selected,
                     // update the fields to allow the user to enter a new pitcher
                     // Also sends the pitcher's stats after changing pitchers
-                    //mPitcherFirst.setEnabled(true);
-                    //mPitcherLast.setEnabled(true);
                     mSpinnerPitchers.setEnabled(true);
 
                     String eventID = Utilities.createRandomHex(6);
@@ -654,10 +649,10 @@ public class TaggingActivity extends Activity {
             }
         });
 
+        // TODO needs refactoring
         mUndo.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                // TODO needs refactoring
                 if (1 == undoPitchRegion) {
                     mEventPitchCount.setText(Integer.toString(--eventPitchCount));
                     mEventStrikes.setText(Integer.toString(--eventStrikesCount));
@@ -877,9 +872,6 @@ public class TaggingActivity extends Activity {
     }
 
     private void savePitcherInfo() {
-        //pitcherFirstName = mPitcherFirst.getText().toString().trim();
-        //pitcherLastName = mPitcherLast.getText().toString().trim();
-        //pitcherName = pitcherFirstName + " " + pitcherLastName;
         pitcherName = mSpinnerPitchers.getSelectedItem().toString();
         pitcherSet = true;
     }

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
@@ -9,8 +9,9 @@ import java.util.Date;
 public class EventStats {
 
     // Change pending
-    public String eventDate;
     public int eventID;
+    public String eventName;
+    public String eventDate;
     public int playerID;
     public int teamID;
     public int pitchCount;
@@ -35,11 +36,12 @@ public class EventStats {
 
     public EventStats() { }
 
-    public EventStats(String eventDate, int eventID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    public EventStats(int eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                  int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
-        this.eventDate = eventDate;
         this.eventID = eventID;
+        this.eventName = eventName;
+        this.eventDate = eventDate;
         this.playerID = playerID;
         this.teamID = teamID;
         this.pitchCount = pitchCount;

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
@@ -9,7 +9,7 @@ import java.util.Date;
 public class EventStats {
 
     // Change pending
-    public int eventID;
+    public String eventID;
     public String eventName;
     public String eventDate;
     public int playerID;
@@ -36,7 +36,7 @@ public class EventStats {
 
     public EventStats() { }
 
-    public EventStats(int eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    public EventStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                  int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
         this.eventID = eventID;

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
@@ -1,13 +1,16 @@
 package pitcherseye.pitcherseye.Objects;
 
+import java.util.Date;
+
 /**
  * Created by Connor on 2/25/2018.
  */
 
-public class GameStats {
+public class EventStats {
 
     // Change pending
-    public int gameID;
+    public String eventDate;
+    public int eventID;
     public int playerID;
     public int teamID;
     public int pitchCount;
@@ -23,12 +26,20 @@ public class GameStats {
     public int R3C2Count;
     public int R3C3Count;
 
-    public GameStats() { }
+    /* TODO:
+        Will want to add:
+            - Event name
+            - Event date
+            - Array of pitcher IDs
+     */
 
-    public GameStats(int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    public EventStats() { }
+
+    public EventStats(String eventDate, int eventID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                  int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
-        this.gameID = gameID;
+        this.eventDate = eventDate;
+        this.eventID = eventID;
         this.playerID = playerID;
         this.teamID = teamID;
         this.pitchCount = pitchCount;

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/EventStats.java
@@ -26,6 +26,11 @@ public class EventStats {
     public int R3C1Count;
     public int R3C2Count;
     public int R3C3Count;
+    public int fastballCount;
+    public int changeupCount;
+    public int curveballCount;
+    public int sliderCount;
+    public int otherCount;
 
     /* TODO:
         Will want to add:
@@ -38,7 +43,8 @@ public class EventStats {
 
     public EventStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
-                 int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
+                 int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
+                      int changeupCount, int curveballCount, int sliderCount, int otherCount) {
         this.eventID = eventID;
         this.eventName = eventName;
         this.eventDate = eventDate;
@@ -56,5 +62,10 @@ public class EventStats {
         this.R3C1Count = R3C1Count;
         this.R3C2Count = R3C2Count;
         this.R3C3Count = R3C3Count;
+        this.fastballCount = fastballCount;
+        this.changeupCount = changeupCount;
+        this.curveballCount = curveballCount;
+        this.sliderCount = sliderCount;
+        this.otherCount = otherCount;
     }
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/GameStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/GameStats.java
@@ -4,7 +4,7 @@ package pitcherseye.pitcherseye.Objects;
  * Created by Connor on 2/25/2018.
  */
 
-public class PitchingStats {
+public class GameStats {
 
     // Change pending
     public int gameID;
@@ -23,9 +23,9 @@ public class PitchingStats {
     public int R3C2Count;
     public int R3C3Count;
 
-    public PitchingStats() { }
+    public GameStats() { }
 
-    public PitchingStats(int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+    public GameStats(int gameID, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
                  int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count) {
         this.gameID = gameID;

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/PitcherStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/PitcherStats.java
@@ -12,6 +12,7 @@ public class PitcherStats {
     public String eventID;
     public String eventName;
     public String eventDate;
+    public String playerName;
     public int playerID;
     public int teamID;
     public int pitchCount;
@@ -41,14 +42,16 @@ public class PitcherStats {
 
     public PitcherStats() {}
 
-    public PitcherStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
-                      int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
-                      int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
-                      int changeupCount, int curveballCount, int sliderCount, int otherCount) {
+    public PitcherStats(String eventID, String eventName, String eventDate, int playerID, String playerName,
+                        int teamID, int pitchCount, int strikeCount, int ballCount,
+                        int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
+                        int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
+                        int changeupCount, int curveballCount, int sliderCount, int otherCount) {
         this.eventID = eventID;
         this.eventName = eventName;
         this.eventDate = eventDate;
         this.playerID = playerID;
+        this.playerName = playerName;
         this.teamID = teamID;
         this.pitchCount = pitchCount;
         this.strikeCount = strikeCount;

--- a/app/src/main/java/pitcherseye/pitcherseye/Objects/PitcherStats.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Objects/PitcherStats.java
@@ -1,0 +1,71 @@
+package pitcherseye.pitcherseye.Objects;
+
+import java.util.Date;
+
+/**
+ * Created by Connor on 2/25/2018.
+ */
+
+public class PitcherStats {
+
+    // Change pending
+    public String eventID;
+    public String eventName;
+    public String eventDate;
+    public int playerID;
+    public int teamID;
+    public int pitchCount;
+    public int strikeCount;
+    public int ballCount;
+    public int R1C1Count;
+    public int R1C2Count;
+    public int R1C3Count;
+    public int R2C1Count;
+    public int R2C2Count;
+    public int R2C3Count;
+    public int R3C1Count;
+    public int R3C2Count;
+    public int R3C3Count;
+    public int fastballCount;
+    public int changeupCount;
+    public int curveballCount;
+    public int sliderCount;
+    public int otherCount;
+
+    /* TODO:
+        Will want to add:
+            - Event name
+            - Event date
+            - Array of pitcher IDs
+     */
+
+    public PitcherStats() {}
+
+    public PitcherStats(String eventID, String eventName, String eventDate, int playerID, int teamID, int pitchCount, int strikeCount, int ballCount,
+                      int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
+                      int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
+                      int changeupCount, int curveballCount, int sliderCount, int otherCount) {
+        this.eventID = eventID;
+        this.eventName = eventName;
+        this.eventDate = eventDate;
+        this.playerID = playerID;
+        this.teamID = teamID;
+        this.pitchCount = pitchCount;
+        this.strikeCount = strikeCount;
+        this.ballCount = ballCount;
+        this.R1C1Count = R1C1Count;
+        this.R1C2Count = R1C2Count;
+        this.R1C3Count = R1C3Count;
+        this.R2C1Count = R2C1Count;
+        this.R2C2Count = R2C2Count;
+        this.R2C3Count = R2C3Count;
+        this.R3C1Count = R3C1Count;
+        this.R3C2Count = R3C2Count;
+        this.R3C3Count = R3C3Count;
+        this.fastballCount = fastballCount;
+        this.changeupCount = changeupCount;
+        this.curveballCount = curveballCount;
+        this.sliderCount = sliderCount;
+        this.otherCount = otherCount;
+    }
+}

--- a/app/src/main/java/pitcherseye/pitcherseye/Utilities.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Utilities.java
@@ -3,11 +3,24 @@ package pitcherseye.pitcherseye;
 import android.app.Activity;
 import android.view.inputmethod.InputMethodManager;
 
+import java.util.Random;
+
 /**
  * Created by Connor on 2/6/2018.
  */
 
 public class Utilities {
+
+    // Method to generate a random Hex number for IDs
+    public static String createRandomHex(int length) {
+        Random random = new Random();
+        StringBuilder sb = new StringBuilder();
+
+        while(sb.length() < length) {
+            sb.append(Integer.toHexString(random.nextInt()));
+        }
+        return sb.toString();
+    }
 
     // Method to help hide virtual keyboard
     public static void hideSoftKeyboard(Activity activity) {

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -280,13 +280,73 @@
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
         app:layout_constraintTop_toBottomOf="@id/txt_R3C2"/>
 
+
+    <!-- Results -->
+
+    <!-- Events -->
+    <Button
+        android:id="@+id/btn_result_fastball"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="FB"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
+
+    <Button
+        android:id="@+id/btn_result_changeup"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:text="CH"
+        app:layout_constraintStart_toEndOf="@+id/btn_result_fastball"
+        app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
+
+    <Button
+        android:id="@+id/btn_result_curve"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:text="Cur"
+        app:layout_constraintStart_toEndOf="@+id/btn_result_changeup"
+        app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
+
+    <Button
+        android:id="@+id/btn_result_slider"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="SL"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_fastball" />
+
+    <Button
+        android:id="@+id/btn_result_other"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="OTHER"
+        app:layout_constraintStart_toEndOf="@+id/btn_result_slider"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_changeup" />
+
+    <!-- Pitch Results -->
+    <Button
+        android:id="@+id/btn_result_hit"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Hit"
+        app:layout_constraintStart_toStartOf="@id/guidelineVertEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_slider" />
+
     <Button
         android:id="@+id/btn_finish_game"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="Finish Game"
-        app:layout_constraintLeft_toRightOf="@+id/guidelineVertStats"
-        app:layout_constraintBottom_toTopOf="parent" />
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toRightOf="parent" />
 
     <android.support.constraint.Guideline
         android:id="@+id/guideline"
@@ -315,6 +375,5 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.7" />
-
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -130,6 +130,17 @@
         app:layout_constraintStart_toEndOf="@+id/chck_bx_event_location"
         app:layout_constraintTop_toTopOf="@+id/edt_txt_event_name_entry" />
 
+    <Spinner
+        android:id="@+id/spin_pitcher_names"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/btn_event_pitcher"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertStats"
+        app:layout_constraintTop_toTopOf="@+id/btn_event_pitcher" />
+
     <Button
         android:id="@+id/btn_event_pitcher"
         android:layout_width="wrap_content"
@@ -417,6 +428,16 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintRight_toRightOf="parent" />
 
+    <Button
+        android:id="@+id/btn_undo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/string_undo"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btn_finish_game"/>
+
     <android.support.constraint.Guideline
         android:id="@+id/guideline"
         android:layout_width="wrap_content"
@@ -458,26 +479,5 @@
         android:layout_height="wrap_content"
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.8" />
-
-    <Button
-        android:id="@+id/btn_undo"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:text="@string/string_undo"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/btn_finish_game"/>
-
-    <Spinner
-        android:id="@+id/spin_pitcher_names"
-        android:layout_width="200dp"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="4dp"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="16dp"
-        app:layout_constraintEnd_toStartOf="@+id/btn_event_pitcher"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVertStats"
-        app:layout_constraintTop_toTopOf="@+id/btn_event_pitcher" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -331,14 +331,6 @@
         app:layout_constraintTop_toBottomOf="@+id/btn_result_changeup" />
 
     <!-- Pitch Results -->
-    <Button
-        android:id="@+id/btn_result_hit"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="16dp"
-        android:text="Hit"
-        app:layout_constraintStart_toStartOf="@id/guidelineVertEvent"
-        app:layout_constraintTop_toBottomOf="@+id/btn_result_slider" />
 
     <Button
         android:id="@+id/btn_finish_game"

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -127,6 +127,7 @@
     <EditText
         android:id="@+id/edt_txt_event_pitcher_first_name"
         android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
         android:layout_marginStart="48dp"
         android:layout_marginTop="16dp"
         android:hint="@string/string_event_pitcher_first"

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -95,14 +95,11 @@
         android:id="@+id/edt_txt_event_name_entry"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
         android:hint="@string/string_event_name"
-        app:layout_constraintBottom_toTopOf="@+id/edt_txt_event_pitcher_first_name"
         app:layout_constraintStart_toStartOf="@+id/guidelineVertGrid"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <CheckBox
         android:id="@+id/chck_bx_event_type"
@@ -124,26 +121,6 @@
         app:layout_constraintLeft_toRightOf="@+id/chck_bx_event_type"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <EditText
-        android:id="@+id/edt_txt_event_pitcher_first_name"
-        android:layout_height="wrap_content"
-        android:layout_width="wrap_content"
-        android:layout_marginStart="48dp"
-        android:layout_marginTop="16dp"
-        android:hint="@string/string_event_pitcher_first"
-        app:layout_constraintStart_toEndOf="@+id/btn_event_confirm"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <EditText
-        android:id="@+id/edt_txt_event_pitcher_last_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="20dp"
-        android:layout_marginTop="16dp"
-        android:hint="@string/string_event_pitcher_last"
-        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_first_name"
-        app:layout_constraintTop_toTopOf="parent" />
-
     <Button
         android:id="@+id/btn_event_confirm"
         android:layout_width="wrap_content"
@@ -157,10 +134,10 @@
         android:id="@+id/btn_event_pitcher"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="32dp"
+        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
         android:text="@string/string_event_confirm_pitcher"
-        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_last_name"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="parent" />
 
     <!-- Statistics -->
@@ -494,12 +471,13 @@
 
     <Spinner
         android:id="@+id/spin_pitcher_names"
-        android:layout_width="300dp"
+        android:layout_width="200dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="4dp"
         android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
-        app:layout_constraintEnd_toEndOf="@+id/btnR3C3"
-        app:layout_constraintStart_toStartOf="@+id/btnR3C1"
-        app:layout_constraintTop_toBottomOf="@+id/btnR3C2" />
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/btn_event_pitcher"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertStats"
+        app:layout_constraintTop_toTopOf="@+id/btn_event_pitcher" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -492,4 +492,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/btn_finish_game"/>
 
+    <Spinner
+        android:id="@+id/spin_pitcher_names"
+        android:layout_width="300dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintEnd_toEndOf="@+id/btnR3C3"
+        app:layout_constraintStart_toStartOf="@+id/btnR3C1"
+        app:layout_constraintTop_toBottomOf="@+id/btnR3C2" />
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -482,4 +482,14 @@
         android:orientation="vertical"
         app:layout_constraintGuide_percent="0.8" />
 
+    <Button
+        android:id="@+id/btn_undo"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:text="@string/string_undo"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/btn_finish_game"/>
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -6,6 +6,8 @@
     android:layout_height="match_parent"
     tools:context="pitcherseye.pitcherseye.Activities.TaggingActivity">
 
+    <!-- Button Grid -->
+
     <Button
         android:background="@drawable/grid_button"
         android:id="@+id/btnR1C1"
@@ -86,6 +88,82 @@
         android:layout_height="wrap_content"
         app:layout_constraintLeft_toRightOf="@+id/btnR3C2"
         app:layout_constraintTop_toBottomOf="@id/btnR2C2" />
+
+    <!-- Event Entry -->
+
+    <EditText
+        android:id="@+id/edt_txt_event_name_entry"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        android:hint="@string/string_event_name"
+        app:layout_constraintBottom_toTopOf="@+id/edt_txt_event_pitcher_first_name"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertGrid"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <CheckBox
+        android:id="@+id/chck_bx_event_type"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:layout_marginStart="24dp"
+        android:text="@string/string_event_type"
+        app:layout_constraintBottom_toTopOf="@+id/edt_txt_event_pitcher_last_name"
+        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_name_entry" />
+
+    <CheckBox
+        android:id="@+id/chck_bx_event_location"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="20dp"
+        android:text="@string/string_event_location"
+        app:layout_constraintLeft_toRightOf="@+id/chck_bx_event_type"
+        app:layout_constraintTop_toTopOf="@+id/chck_bx_event_type" />
+
+    <EditText
+        android:id="@+id/edt_txt_event_pitcher_first_name"
+        android:layout_width="84dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginStart="8dp"
+        android:hint="@string/string_event_pitcher_first"
+        app:layout_constraintBottom_toTopOf="@+id/btnR1C1"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertGrid" />
+
+    <EditText
+        android:id="@+id/edt_txt_event_pitcher_last_name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:hint="@string/string_event_pitcher_last"
+        app:layout_constraintBottom_toTopOf="@+id/btnR1C3"
+        app:layout_constraintEnd_toEndOf="@+id/btnR1C3"
+        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_first_name" />
+
+    <Button
+        android:id="@+id/btn_event_confirm"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="8dp"
+        android:text="@string/string_event_confirm"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toTopOf="@+id/edt_txt_event_name_entry" />
+
+    <Button
+        android:id="@+id/btn_event_pitcher"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/string_event_confirm_pitcher"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toTopOf="@+id/edt_txt_event_pitcher_first_name" />
+
+    <!-- Statistics -->
 
     <TextView
         android:id="@+id/txt_pitch_count_label"
@@ -225,13 +303,19 @@
         app:layout_constraintGuide_percent="0.1" />
 
     <android.support.constraint.Guideline
+        android:id="@+id/guidelineVertEvent"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent=".4"
+        />
+
+    <android.support.constraint.Guideline
         android:id="@+id/guidelineVertStats"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent="0.6" />
-
-
+        app:layout_constraintGuide_percent="0.7" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -166,39 +166,71 @@
     <!-- Statistics -->
 
     <TextView
+        android:id="@+id/txt_pitcher_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:text="@string/string_pitcher_count_label"
+        app:layout_constraintBottom_toTopOf="@id/txt_pitcher_pitch_count"
+        app:layout_constraintLeft_toLeftOf="@id/guidelineVertPitcherStats"/>
+
+    <TextView
+        android:id="@+id/txt_event_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="20dp"
+        android:text="@string/string_event_count_label"
+        app:layout_constraintBottom_toTopOf="@+id/txt_event_pitch_count"
+        app:layout_constraintLeft_toLeftOf="@id/guidelineVertEventStats" />
+
+    <TextView
         android:id="@+id/txt_pitch_count_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_pitch_count"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintBottom_toTopOf="@id/btnR1C1" />
+        app:layout_constraintTop_toTopOf="@+id/btnR1C1" />
 
     <TextView
-        android:id="@+id/txt_pitch_count_counter"
+        android:id="@+id/txt_pitcher_pitch_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@id/txt_pitch_count_label"
-        app:layout_constraintBottom_toTopOf="@id/btnR1C1" />
+        app:layout_constraintStart_toEndOf="@id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_pitch_count_label" />
+
+    <TextView
+        android:id="@+id/txt_event_pitch_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintStart_toEndOf="@id/guidelineVertEventStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_pitch_count_label" />
 
     <TextView
         android:id="@+id/txt_strikes_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/string_strikes"
         android:layout_marginTop="20dp"
+        android:text="@string/string_strikes"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toTopOf="@id/btnR1C1" />
+        app:layout_constraintTop_toBottomOf="@+id/txt_pitch_count_label" />
 
     <TextView
-        android:id="@+id/txt_strikes_counter"
+        android:id="@+id/txt_pitcher_strikes_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        android:layout_marginTop="20dp"
-        app:layout_constraintLeft_toRightOf="@id/txt_strikes_label"
-        app:layout_constraintTop_toTopOf="@id/btnR1C1" />
+        app:layout_constraintLeft_toRightOf="@id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_strikes_label" />
 
+    <TextView
+        android:id="@+id/txt_event_strikes_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintStart_toEndOf="@id/guidelineVertEventStats"
+        app:layout_constraintTop_toTopOf="@id/txt_strikes_label" />
 
     <TextView
         android:id="@+id/txt_balls_label"
@@ -210,11 +242,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_strikes_label" />
 
     <TextView
-        android:id="@+id/txt_balls_counter"
+        android:id="@+id/txt_pitcher_balls_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_balls_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@id/txt_balls_label"/>
+
+    <TextView
+        android:id="@+id/txt_event_balls_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@id/txt_balls_label"/>
 
     <TextView
@@ -227,11 +267,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_balls_label" />
 
     <TextView
-        android:id="@+id/txt_fastball_counter"
+        android:id="@+id/txt_pitcher_fastball_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_fastball_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_fastball_label" />
+
+    <TextView
+        android:id="@+id/txt_event_fastball_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@+id/txt_fastball_label" />
 
     <TextView
@@ -244,11 +292,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_fastball_label" />
 
     <TextView
-        android:id="@+id/txt_changeup_counter"
+        android:id="@+id/txt_pitcher_changeup_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_changeup_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_changeup_label" />
+
+    <TextView
+        android:id="@+id/txt_event_changeup_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@+id/txt_changeup_label" />
 
     <TextView
@@ -261,11 +317,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_changeup_label" />
 
     <TextView
-        android:id="@+id/txt_curveball_counter"
+        android:id="@+id/txt_pitcher_curveball_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_curveball_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_curveball_label" />
+
+    <TextView
+        android:id="@+id/txt_event_curveball_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@+id/txt_curveball_label" />
 
     <TextView
@@ -278,11 +342,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_curveball_label" />
 
     <TextView
-        android:id="@+id/txt_slider_counter"
+        android:id="@+id/txt_pitcher_slider_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_slider_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_slider_label" />
+
+    <TextView
+        android:id="@+id/txt_event_slider_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@+id/txt_slider_label" />
 
     <TextView
@@ -295,11 +367,19 @@
         app:layout_constraintTop_toBottomOf="@id/txt_slider_label" />
 
     <TextView
-        android:id="@+id/txt_other_counter"
+        android:id="@+id/txt_pitcher_other_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/string_initialize_count"
-        app:layout_constraintLeft_toRightOf="@+id/txt_other_label"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertPitcherStats"
+        app:layout_constraintTop_toTopOf="@+id/txt_other_label" />
+
+    <TextView
+        android:id="@+id/txt_event_other_count"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/guidelineVertEventStats"
         app:layout_constraintTop_toTopOf="@+id/txt_other_label" />
 
 
@@ -386,6 +466,20 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.6" />
+
+    <android.support.constraint.Guideline
+        android:id="@+id/guidelineVertPitcherStats"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
         app:layout_constraintGuide_percent="0.7" />
+
+    <android.support.constraint.Guideline
+        android:id="@+id/guidelineVertEventStats"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.8" />
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -101,67 +101,66 @@
         android:hint="@string/string_event_name"
         app:layout_constraintBottom_toTopOf="@+id/edt_txt_event_pitcher_first_name"
         app:layout_constraintStart_toStartOf="@+id/guidelineVertGrid"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0.0" />
 
     <CheckBox
         android:id="@+id/chck_bx_event_type"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="16dp"
-        android:layout_marginStart="24dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="20dp"
         android:text="@string/string_event_type"
-        app:layout_constraintBottom_toTopOf="@+id/edt_txt_event_pitcher_last_name"
-        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_name_entry" />
+        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_name_entry"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <CheckBox
         android:id="@+id/chck_bx_event_location"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="20dp"
+        android:layout_marginTop="20dp"
         android:text="@string/string_event_location"
         app:layout_constraintLeft_toRightOf="@+id/chck_bx_event_type"
-        app:layout_constraintTop_toTopOf="@+id/chck_bx_event_type" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/edt_txt_event_pitcher_first_name"
-        android:layout_width="84dp"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="48dp"
+        android:layout_marginTop="16dp"
         android:hint="@string/string_event_pitcher_first"
-        app:layout_constraintBottom_toTopOf="@+id/btnR1C1"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVertGrid" />
+        app:layout_constraintStart_toEndOf="@+id/btn_event_confirm"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <EditText
         android:id="@+id/edt_txt_event_pitcher_last_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="8dp"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="20dp"
+        android:layout_marginTop="16dp"
         android:hint="@string/string_event_pitcher_last"
-        app:layout_constraintBottom_toTopOf="@+id/btnR1C3"
-        app:layout_constraintEnd_toEndOf="@+id/btnR1C3"
-        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_first_name" />
+        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_first_name"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <Button
         android:id="@+id/btn_event_confirm"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:layout_marginTop="8dp"
+        android:layout_marginStart="32dp"
         android:text="@string/string_event_confirm"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintStart_toEndOf="@+id/chck_bx_event_location"
         app:layout_constraintTop_toTopOf="@+id/edt_txt_event_name_entry" />
 
     <Button
         android:id="@+id/btn_event_pitcher"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginStart="32dp"
+        android:layout_marginTop="16dp"
         android:text="@string/string_event_confirm_pitcher"
-        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
-        app:layout_constraintTop_toTopOf="@+id/edt_txt_event_pitcher_first_name" />
+        app:layout_constraintStart_toEndOf="@+id/edt_txt_event_pitcher_last_name"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <!-- Statistics -->
 
@@ -307,8 +306,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_percent=".4"
-        />
+        app:layout_constraintGuide_begin="512dp" />
 
     <android.support.constraint.Guideline
         android:id="@+id/guidelineVertStats"

--- a/app/src/main/res/layout/activity_tagging.xml
+++ b/app/src/main/res/layout/activity_tagging.xml
@@ -218,67 +218,89 @@
         app:layout_constraintTop_toTopOf="@id/txt_balls_label"/>
 
     <TextView
-        android:id="@+id/txt_R1C3"
+        android:id="@+id/txt_fastball_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R1C3: "
         android:layout_marginTop="20dp"
+        android:text="@string/string_pitch_fastball_count"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_balls_label"/>
+        app:layout_constraintTop_toBottomOf="@id/txt_balls_label" />
 
     <TextView
-        android:id="@+id/txt_R2C1"
+        android:id="@+id/txt_fastball_counter"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R2C1: "
-        android:layout_marginTop="20dp"
-        app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R1C3"/>
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/txt_fastball_label"
+        app:layout_constraintTop_toTopOf="@+id/txt_fastball_label" />
 
     <TextView
-        android:id="@+id/txt_R2C2"
+        android:id="@+id/txt_changeup_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R2C2: "
         android:layout_marginTop="20dp"
+        android:text="@string/string_pitch_changeup_count"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R2C1"/>
+        app:layout_constraintTop_toBottomOf="@id/txt_fastball_label" />
 
     <TextView
-        android:id="@+id/txt_R2C3"
+        android:id="@+id/txt_changeup_counter"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R2C3: "
-        android:layout_marginTop="20dp"
-        app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R2C2"/>
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/txt_changeup_label"
+        app:layout_constraintTop_toTopOf="@+id/txt_changeup_label" />
 
     <TextView
-        android:id="@+id/txt_R3C1"
+        android:id="@+id/txt_curveball_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R3C1: "
         android:layout_marginTop="20dp"
+        android:text="@string/string_pitch_curveballs_count"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R2C3" />
+        app:layout_constraintTop_toBottomOf="@id/txt_changeup_label" />
 
     <TextView
-        android:id="@+id/txt_R3C2"
+        android:id="@+id/txt_curveball_counter"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R3C2: "
-        android:layout_marginTop="20dp"
-        app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R3C1"/>
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/txt_curveball_label"
+        app:layout_constraintTop_toTopOf="@+id/txt_curveball_label" />
 
     <TextView
-        android:id="@+id/txt_R3C3"
+        android:id="@+id/txt_slider_label"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="R3C3: "
         android:layout_marginTop="20dp"
+        android:text="@string/string_pitch_sliders_count"
         app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
-        app:layout_constraintTop_toBottomOf="@id/txt_R3C2"/>
+        app:layout_constraintTop_toBottomOf="@id/txt_curveball_label" />
+
+    <TextView
+        android:id="@+id/txt_slider_counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/txt_slider_label"
+        app:layout_constraintTop_toTopOf="@+id/txt_slider_label" />
+
+    <TextView
+        android:id="@+id/txt_other_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:text="@string/string_pitch_other_count"
+        app:layout_constraintLeft_toRightOf="@id/guidelineVertStats"
+        app:layout_constraintTop_toBottomOf="@id/txt_slider_label" />
+
+    <TextView
+        android:id="@+id/txt_other_counter"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/string_initialize_count"
+        app:layout_constraintLeft_toRightOf="@+id/txt_other_label"
+        app:layout_constraintTop_toTopOf="@+id/txt_other_label" />
 
 
     <!-- Results -->
@@ -288,7 +310,7 @@
         android:id="@+id/btn_result_fastball"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="FB"
+        android:text="@string/string_pitch_fastball"
         app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
         app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
 
@@ -296,39 +318,37 @@
         android:id="@+id/btn_result_changeup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:text="CH"
-        app:layout_constraintStart_toEndOf="@+id/btn_result_fastball"
-        app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
+        android:layout_marginTop="8dp"
+        android:text="@string/string_pitch_changeup"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_fastball" />
 
     <Button
         android:id="@+id/btn_result_curve"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
-        android:text="Cur"
-        app:layout_constraintStart_toEndOf="@+id/btn_result_changeup"
-        app:layout_constraintTop_toTopOf="@+id/btnR1C3" />
+        android:layout_marginTop="8dp"
+        android:text="@string/string_pitch_curveball"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_changeup" />
 
     <Button
         android:id="@+id/btn_result_slider"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:text="SL"
+        android:text="@string/string_pitch_slider"
         app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
-        app:layout_constraintTop_toBottomOf="@+id/btn_result_fastball" />
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_curve" />
 
     <Button
         android:id="@+id/btn_result_other"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
-        android:text="OTHER"
-        app:layout_constraintStart_toEndOf="@+id/btn_result_slider"
-        app:layout_constraintTop_toBottomOf="@+id/btn_result_changeup" />
+        android:text="@string/string_pitch_other"
+        app:layout_constraintStart_toStartOf="@+id/guidelineVertEvent"
+        app:layout_constraintTop_toBottomOf="@+id/btn_result_slider" />
 
     <!-- Pitch Results -->
 
@@ -359,7 +379,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="512dp" />
+        app:layout_constraintGuide_percent="0.4" />
 
     <android.support.constraint.Guideline
         android:id="@+id/guidelineVertStats"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,6 +24,16 @@
     <string name="string_strikes">Strikes</string>
     <string name="string_balls">Balls</string>
     <string name="string_initialize_count">0</string>
+    <string name="string_pitch_fastball_count">Fastballs: </string>
+    <string name="string_pitch_changeup_count">Changeups: </string>
+    <string name="string_pitch_sliders_count">Sliders: </string>
+    <string name="string_pitch_curveballs_count">Curveballs: </string>
+    <string name="string_pitch_other_count">Other: </string>
+    <string name="string_pitch_fastball">FB</string>
+    <string name="string_pitch_changeup">ChU</string>
+    <string name="string_pitch_sliders">SL</string>
+    <string name="string_pitch_curveballs">CurB</string>
+    <string name="string_pitch_other">Oth</string>
 
     <!-- Event Entry -->
     <string name="string_event_name">Event Name</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,8 +21,8 @@
 
     <!-- Tagging -->
     <string name="string_pitch_count">Pitch Count: </string>
-    <string name="string_strikes">Strikes</string>
-    <string name="string_balls">Balls</string>
+    <string name="string_strikes">Strikes: </string>
+    <string name="string_balls">Balls: </string>
     <string name="string_initialize_count">0</string>
     <string name="string_pitch_fastball_count">Fastballs: </string>
     <string name="string_pitch_changeup_count">Changeups: </string>
@@ -31,8 +31,8 @@
     <string name="string_pitch_other_count">Other: </string>
     <string name="string_pitch_fastball">FB</string>
     <string name="string_pitch_changeup">ChU</string>
-    <string name="string_pitch_sliders">SL</string>
-    <string name="string_pitch_curveballs">CurB</string>
+    <string name="string_pitch_slider">SL</string>
+    <string name="string_pitch_curveball">CurB</string>
     <string name="string_pitch_other">Oth</string>
 
     <!-- Event Entry -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,7 +21,16 @@
 
     <!-- Tagging -->
     <string name="string_pitch_count">Pitch Count: </string>
-    <string name="string_strikes">Strikes: </string>
-    <string name="string_balls">Balls: </string>
+    <string name="string_strikes">Strikes</string>
+    <string name="string_balls">Balls</string>
     <string name="string_initialize_count">0</string>
+
+    <!-- Event Entry -->
+    <string name="string_event_name">Event Name</string>
+    <string name="string_event_type">Game</string>
+    <string name="string_event_location">Home</string>
+    <string name="string_event_pitcher_first">P FName</string>
+    <string name="string_event_pitcher_last">P LName</string>
+    <string name="string_event_confirm">Confirm Event</string>
+    <string name="string_event_confirm_pitcher">Confirm Pitcher</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,4 +45,6 @@
     <string name="string_event_pitcher_last">P LName</string>
     <string name="string_event_confirm">Confirm Event</string>
     <string name="string_event_confirm_pitcher">Confirm Pitcher</string>
+    <string name="string_finish_game">Finish Game</string>
+    <string name="string_undo">Undo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,8 @@
     <string name="string_registration_id">Registration ID</string>
 
     <!-- Tagging -->
+    <string name="string_pitcher_count_label">Pitcher</string>
+    <string name="string_event_count_label">Event</string>
     <string name="string_pitch_count">Pitch Count: </string>
     <string name="string_strikes">Strikes: </string>
     <string name="string_balls">Balls: </string>


### PR DESCRIPTION
## [Overview](#overview)
Oh boy this one is a doozy. This branch handles the TaggingActivity and adds the EventStats and the PitchingStats objects. 

This also adds separation between individual pitcher and event statistics, an undo button for the most recent pitch, a counter to display results in real-time, and the option to switch pitchers during the event.

## [Background Context](#background)
This branch only handles the workflows, we will be writing a technical debt ticket to refactor some event handlers (which it could use).

## [Illustrations](#illustrations)

## [Acceptance Criteria](#acceptance-criteria)
 - [ ] You cannot start tagging a game until the event name has been entered and a pitcher has been selected
 - [ ] You cannot start an event with selecting the empty string in the spinner.
 - [ ] Changing the pitcher during the event will save the statistics in Firebase and reflect correctly
 - [ ] Selecting "Finish Game" will save the event statistics in Firebase and reflect correctly
 - [ ] The undo button will adjust statistics correctly