### PR TITLE
Confirm RecyclerView Deletion

### DIFF
--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/LoginActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/LoginActivity.java
@@ -26,6 +26,7 @@ import pitcherseye.pitcherseye.Utilities;
 
 public class LoginActivity extends AppCompatActivity {
 
+    public static Activity loginActivity;
     // UI Components
     Button mLoginButton;
     EditText mLoginEmail;
@@ -33,11 +34,13 @@ public class LoginActivity extends AppCompatActivity {
     FirebaseAuth mAuth;
     ProgressBar mLogInProgress;
     TextView mSignUp;
-
-    public static Activity loginActivity;
-
     // Request Code
     int REQUEST_CODE_CALCULATE = 0;
+
+    public static Intent newIntent(Context packageContext) {
+        Intent i = new Intent(packageContext, LoginActivity.class);
+        return i;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -110,7 +113,7 @@ public class LoginActivity extends AppCompatActivity {
         }
 
         // Validate password, we'll probably want to require special characters/casing in the future
-        if (password.isEmpty()  || password == null) {
+        if (password.isEmpty() || password == null) {
             mLoginPassword.setError("Password is required.");
             mLoginPassword.requestFocus();
             Log.d("Password", "Password failed" + password);
@@ -133,7 +136,7 @@ public class LoginActivity extends AppCompatActivity {
                 // Hide the progress bar
                 mLogInProgress.setVisibility(View.GONE);
 
-                if(task.isSuccessful()) {
+                if (task.isSuccessful()) {
                     // If the login was successful, direct user to the MainActivity
                     Intent i = MainActivity.newIntent(LoginActivity.this);
                     startActivityForResult(i, REQUEST_CODE_CALCULATE);
@@ -155,11 +158,6 @@ public class LoginActivity extends AppCompatActivity {
                 startActivityForResult(i, REQUEST_CODE_CALCULATE);
             }
         });
-    }
-
-    public static Intent newIntent(Context packageContext) {
-        Intent i = new Intent(packageContext, LoginActivity.class);
-        return i;
     }
 
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/MainActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/MainActivity.java
@@ -24,6 +24,11 @@ public class MainActivity extends AppCompatActivity {
     // Request Code
     int REQUEST_CODE_CALCULATE = 0;
 
+    public static Intent newIntent(Context packageContext) {
+        Intent i = new Intent(packageContext, MainActivity.class);
+        return i;
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -77,10 +82,5 @@ public class MainActivity extends AppCompatActivity {
                 finish(); // Don't add to the backstack
             }
         });
-    }
-
-    public static Intent newIntent(Context packageContext) {
-        Intent i = new Intent(packageContext, MainActivity.class);
-        return i;
     }
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/SignUpActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/SignUpActivity.java
@@ -51,6 +51,11 @@ public class SignUpActivity extends AppCompatActivity {
     String teamID;
     String registrationID;
 
+    public static Intent newIntent(Context packageContext) {
+        Intent i = new Intent(packageContext, SignUpActivity.class);
+        return i;
+    }
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -95,7 +100,7 @@ public class SignUpActivity extends AppCompatActivity {
             return;
         }
         if (validateInput(confirmPassword, mSignUpConfirmPassword, "Password")) return;
-        if(confirmPassword.compareTo(password) != 0) {
+        if (confirmPassword.compareTo(password) != 0) {
             mSignUpConfirmPassword.setError("Passwords do no match.");
             return;
         }
@@ -163,7 +168,7 @@ public class SignUpActivity extends AppCompatActivity {
 
     // Made sure that fields aren't empty
     private boolean validateInput(String checkedString, EditText editText, String errorMessage) {
-        if(checkedString.isEmpty() || checkedString == null) {
+        if (checkedString.isEmpty() || checkedString == null) {
             editText.setError(errorMessage + " is required.");
             editText.requestFocus();
             return true;
@@ -178,10 +183,5 @@ public class SignUpActivity extends AppCompatActivity {
 
         // Send user information to Firebase
         mDatabase.child("users").child(userID).setValue(user);
-    }
-
-    public static Intent newIntent(Context packageContext) {
-        Intent i = new Intent(packageContext, SignUpActivity.class);
-        return i;
     }
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/StatisticsActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/StatisticsActivity.java
@@ -1,9 +1,11 @@
 package pitcherseye.pitcherseye.Activities;
 
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -23,12 +25,6 @@ import pitcherseye.pitcherseye.Objects.PitcherStats;
 import pitcherseye.pitcherseye.R;
 
 public class StatisticsActivity extends AppCompatActivity {
-    private static RecyclerView mEventRecyclerView;
-    private DatabaseReference mEventRef;
-    private DatabaseReference mPitcherRef;
-    private static Context mContext;
-    private TabLayout mStatisticsTabLayout;
-
     public static ArrayList<String> eventNameList = new ArrayList<>();
     public static ArrayList<Integer> eventPitchCount = new ArrayList<>();
     public static ArrayList<Integer> eventStrikeCountArrayList = new ArrayList<>();
@@ -51,7 +47,6 @@ public class StatisticsActivity extends AppCompatActivity {
     public static ArrayList<Integer> eventBallHighArrayList = new ArrayList<>();
     public static ArrayList<Integer> eventBallLeftArrayList = new ArrayList<>();
     public static ArrayList<Integer> eventBallRightArrayList = new ArrayList<>();
-
     public static ArrayList<String> pitcherNameList = new ArrayList<>();
     public static ArrayList<String> pitcherEventNameList = new ArrayList<>();
     public static ArrayList<Integer> pitcherPitchCount = new ArrayList<>();
@@ -75,8 +70,18 @@ public class StatisticsActivity extends AppCompatActivity {
     public static ArrayList<Integer> pitcherBallHighArrayList = new ArrayList<>();
     public static ArrayList<Integer> pitcherBallLeftArrayList = new ArrayList<>();
     public static ArrayList<Integer> pitcherBallRightArrayList = new ArrayList<>();
-    static FirebaseRecyclerAdapter<EventStats,EventStatsViewHolder> eventRecyclerAdapter;
+    static FirebaseRecyclerAdapter<EventStats, EventStatsViewHolder> eventRecyclerAdapter;
     static FirebaseRecyclerAdapter<PitcherStats, PitcherStatsViewHolder> pitcherRecyclerAdapter;
+    private static RecyclerView mEventRecyclerView;
+    private static Context mContext;
+    private DatabaseReference mEventRef;
+    private DatabaseReference mPitcherRef;
+    private TabLayout mStatisticsTabLayout;
+
+    public static Intent newIntent(Context packageContext) {
+        Intent i = new Intent(packageContext, StatisticsActivity.class);
+        return i;
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -102,12 +107,12 @@ public class StatisticsActivity extends AppCompatActivity {
 
             @Override
             public void onTabUnselected(TabLayout.Tab tab) {
-
+                Log.i("Tab unselected", tab.toString());
             }
 
             @Override
             public void onTabReselected(TabLayout.Tab tab) {
-
+                Log.i("Tab reselected", tab.toString());
             }
         });
 
@@ -167,6 +172,61 @@ public class StatisticsActivity extends AppCompatActivity {
         mEventRecyclerView.setAdapter(eventRecyclerAdapter);
     }
 
+    // This is an AlertDialog confirming or canceling the deletion of an item in the RecylerView
+    // Selecting cancel will just dismiss the dialog, but confirming with the delete button
+    // will delete the passed RecyclerView's adapter.
+    private void deleteRecyclerAlertDialog(final String message, final String title, final FirebaseRecyclerAdapter recyclerAdapter, final int layoutPostition) {
+        final AlertDialog.Builder dialog = new AlertDialog.Builder(mContext);
+        dialog.setTitle(title).setMessage(message).setPositiveButton(
+                "Delete", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        recyclerAdapter.getRef(layoutPostition).removeValue();
+                        Log.i("Delete pressed", title);
+                    }
+                }
+        ).setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                Log.i("Delete cancelled", title);
+                dialogInterface.dismiss();
+            }
+        }).show();
+    }
+
+    // Clear out the ArrayLists to ensure that we're reloading them
+    @Override
+    public void onBackPressed() {
+        eventNameList.clear();
+        eventPitchCount.clear();
+        eventStrikeCountArrayList.clear();
+        eventR1C1ArrayList.clear();
+        eventR1C2ArrayList.clear();
+        eventR1C3ArrayList.clear();
+        eventR2C1ArrayList.clear();
+        eventR2C2ArrayList.clear();
+        eventR2C3ArrayList.clear();
+        eventR3C1ArrayList.clear();
+        eventR3C2ArrayList.clear();
+        eventR3C3ArrayList.clear();
+
+        pitcherNameList.clear();
+        pitcherEventNameList.clear();
+        pitcherPitchCount.clear();
+        pitcherStrikeCountArrayList.clear();
+        pitcherR1C1ArrayList.clear();
+        pitcherR1C2ArrayList.clear();
+        pitcherR1C3ArrayList.clear();
+        pitcherR2C1ArrayList.clear();
+        pitcherR2C2ArrayList.clear();
+        pitcherR2C3ArrayList.clear();
+        pitcherR3C1ArrayList.clear();
+        pitcherR3C2ArrayList.clear();
+        pitcherR3C3ArrayList.clear();
+
+        finish();
+    }
+
     public static class EventStatsViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
         View mView;
         TextView mStatisticsEventName;
@@ -187,18 +247,18 @@ public class StatisticsActivity extends AppCompatActivity {
             mStatisticsViewEvent = (ImageButton) itemView.findViewById(R.id.img_button_view_event);
             mDeleteRecylerStatistic = (ImageButton) itemView.findViewById(R.id.img_button_event_delete);
 
-            // TODO
             mDeleteRecylerStatistic.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    Log.e("Delete pressed", "event");
-                    eventRecyclerAdapter.getRef(getLayoutPosition()).removeValue();
+                    StatisticsActivity statisticsActivity = new StatisticsActivity();
+                    statisticsActivity.deleteRecyclerAlertDialog("\nDo you want to permanently delete this event's statistics?",
+                            "Delete Event Stats",
+                            eventRecyclerAdapter, getLayoutPosition());
                 }
             });
 
             mStatisticsViewEvent.setOnClickListener(this);
         }
-
 
         @Override
         public void onClick(View view) {
@@ -234,45 +294,44 @@ public class StatisticsActivity extends AppCompatActivity {
             mContext.startActivity(intent);
         }
 
-        // Image Button TODO
-
-        public void setEventName(String eventName)
-        {
+        public void setEventName(String eventName) {
             mStatisticsEventName.setText(eventName + "");
         }
 
         public void setEventDate(String eventDate) {
             mStatisticsDate.setText(eventDate + "");
         }
+
         public void setEventType(Boolean eventType) {
             // TODO
             // Need to fix the null error once we sanitize Firebase
             if (eventType == null) {
                 mStatisticsEventType.setText(R.string.string_reports_location_type_placeholder);
-            } else if (eventType){
+            } else if (eventType) {
                 mStatisticsEventType.setText(R.string.string_reports_type_game);
             } else {
                 mStatisticsEventType.setText(R.string.string_reports_type_practice);
             }
         }
+
         public void setEventLocation(Boolean eventLocation) {
             // TODO
             // Need to fix the null error once we sanitize Firebase
             if (eventLocation == null) {
                 mStatisticsEventLocation.setText(R.string.string_reports_location_type_placeholder);
-            } else if (eventLocation){
+            } else if (eventLocation) {
                 mStatisticsEventLocation.setText(R.string.string_reports_location_home);
             } else {
                 mStatisticsEventLocation.setText(R.string.string_reports_location_away);
             }
         }
 
-        public void loadIndexArray(String eventName, int totalPitchCount,  int position) {
+        public void loadIndexArray(String eventName, int totalPitchCount, int position) {
             eventNameList.add(eventName);
             eventPitchCount.add(totalPitchCount);
             Log.e("Loaded pitch # array", eventNameList.get(position) + "");
         }
-        
+
         public void loadPitchTypeArray(int eventFastballCount, int eventChangeupCount, int eventCurveballCount,
                                        int eventSliderCount, int eventOtherCount, int position) {
             eventFastballCountArrayList.add(eventFastballCount);
@@ -337,12 +396,13 @@ public class StatisticsActivity extends AppCompatActivity {
             mStatisticsPitcherViewEvent = (ImageButton) itemView.findViewById(R.id.img_button_view_pitcher);
             mDeleteRecylerStatistic = (ImageButton) itemView.findViewById(R.id.img_button_pitcher_delete);
 
-            // TODO
             mDeleteRecylerStatistic.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
-                    Log.e("Delete pressed", "pitcher");
-                    pitcherRecyclerAdapter.getRef(getLayoutPosition()).removeValue();
+                    StatisticsActivity statisticsActivity = new StatisticsActivity();
+                    statisticsActivity.deleteRecyclerAlertDialog("\nDo you want to permanently delete this pitcher's statistics?",
+                            "Delete Pitcher Stats",
+                            pitcherRecyclerAdapter, getLayoutPosition());
                 }
             });
 
@@ -385,7 +445,7 @@ public class StatisticsActivity extends AppCompatActivity {
             mContext.startActivity(intent);
         }
 
-        public void loadPitcherIndexArray(String pitcherName, String pitcherEventName, int totalPitchCount,  int position) {
+        public void loadPitcherIndexArray(String pitcherName, String pitcherEventName, int totalPitchCount, int position) {
             pitcherNameList.add(pitcherName);
             pitcherEventNameList.add(pitcherEventName);
             pitcherPitchCount.add(totalPitchCount);
@@ -393,7 +453,7 @@ public class StatisticsActivity extends AppCompatActivity {
         }
 
         public void loadPitcherPitchTypeArray(int pitcherFastballCount, int pitcherChangeupCount, int pitcherCurveballCount,
-                                       int pitcherSliderCount, int pitcherOtherCount, int position) {
+                                              int pitcherSliderCount, int pitcherOtherCount, int position) {
             pitcherFastballCountArrayList.add(pitcherFastballCount);
             pitcherChangeupCountArrayList.add(pitcherChangeupCount);
             pitcherCurveballCountArrayList.add(pitcherCurveballCount);
@@ -404,9 +464,9 @@ public class StatisticsActivity extends AppCompatActivity {
 
         // Load Strike information
         public void loadPitcherStrikeLocationArray(int pitcherStrikeCount, int pitcherR1C1Count, int pitcherR1C2Count, int pitcherR1C3Count,
-                                            int pitcherR2C1Count, int pitcherR2C2Count, int pitcherR2C3Count,
-                                            int pitcherR3C1Count, int pitcherR3C2Count, int pitcherR3C3Count,
-                                            int position) {
+                                                   int pitcherR2C1Count, int pitcherR2C2Count, int pitcherR2C3Count,
+                                                   int pitcherR3C1Count, int pitcherR3C2Count, int pitcherR3C3Count,
+                                                   int position) {
             // Investigate a better model to store these
             pitcherStrikeCountArrayList.add(pitcherStrikeCount);
             pitcherR1C1ArrayList.add(pitcherR1C1Count);
@@ -423,7 +483,7 @@ public class StatisticsActivity extends AppCompatActivity {
 
         // Load Ball information
         public void loadPitcherBallLocationArray(int pitcherBallCount, int pitcherBallLow, int pitcherBallHigh,
-                                          int pitcherBallLeft, int pitcherBallRight, int position) {
+                                                 int pitcherBallLeft, int pitcherBallRight, int position) {
             pitcherBallCountArrayList.add(pitcherBallCount);
             pitcherBallLowArrayList.add(pitcherBallLow);
             pitcherBallHighArrayList.add(pitcherBallHigh);
@@ -432,8 +492,7 @@ public class StatisticsActivity extends AppCompatActivity {
             Log.e("Pitcher Ball Count: ", pitcherBallCountArrayList.get(position) + "");
         }
 
-        public void setPitcherName(String pitcherName)
-        {
+        public void setPitcherName(String pitcherName) {
             mStatisticsPitcherName.setText(pitcherName);
         }
 
@@ -450,7 +509,7 @@ public class StatisticsActivity extends AppCompatActivity {
             // Need to fix the null error once we sanitize Firebase
             if (pitcherEventType == null) {
                 mStatisticsPitcherEventType.setText(R.string.string_reports_location_type_placeholder);
-            } else if (pitcherEventType){
+            } else if (pitcherEventType) {
                 mStatisticsPitcherEventType.setText(R.string.string_reports_type_game);
             } else {
                 mStatisticsPitcherEventType.setText(R.string.string_reports_type_practice);
@@ -462,50 +521,12 @@ public class StatisticsActivity extends AppCompatActivity {
             // Need to fix the null error once we sanitize Firebase
             if (pitcherEventLocation == null) {
                 mStatisticsPitcherEventLocation.setText(R.string.string_reports_location_type_placeholder);
-            } else if (pitcherEventLocation){
+            } else if (pitcherEventLocation) {
                 mStatisticsPitcherEventLocation.setText(R.string.string_reports_location_home);
             } else {
                 mStatisticsPitcherEventLocation.setText(R.string.string_reports_location_away);
             }
         }
-    }
-
-        // Clear out the ArrayLists to ensure that we're reloading them
-    @Override
-    public void onBackPressed() {
-        eventNameList.clear();
-        eventPitchCount.clear();
-        eventStrikeCountArrayList.clear();
-        eventR1C1ArrayList.clear();
-        eventR1C2ArrayList.clear();
-        eventR1C3ArrayList.clear();
-        eventR2C1ArrayList.clear();
-        eventR2C2ArrayList.clear();
-        eventR2C3ArrayList.clear();
-        eventR3C1ArrayList.clear();
-        eventR3C2ArrayList.clear();
-        eventR3C3ArrayList.clear();
-
-        pitcherNameList.clear();
-        pitcherEventNameList.clear();
-        pitcherPitchCount.clear();
-        pitcherStrikeCountArrayList.clear();
-        pitcherR1C1ArrayList.clear();
-        pitcherR1C2ArrayList.clear();
-        pitcherR1C3ArrayList.clear();
-        pitcherR2C1ArrayList.clear();
-        pitcherR2C2ArrayList.clear();
-        pitcherR2C3ArrayList.clear();
-        pitcherR3C1ArrayList.clear();
-        pitcherR3C2ArrayList.clear();
-        pitcherR3C3ArrayList.clear();
-        
-        finish();
-    }
-
-    public static Intent newIntent(Context packageContext) {
-        Intent i = new Intent(packageContext, StatisticsActivity.class);
-        return i;
     }
 
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -1,21 +1,15 @@
 package pitcherseye.pitcherseye.Activities;
 
 import android.app.Activity;
-import android.app.DialogFragment;
 import android.app.FragmentManager;
-import android.app.FragmentTransaction;
 import android.content.Context;
 import android.content.Intent;
-import android.nfc.Tag;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.View;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.EditText;
 import android.widget.ProgressBar;
-import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -23,8 +17,6 @@ import com.google.firebase.database.DataSnapshot;
 import com.google.firebase.database.DatabaseError;
 import com.google.firebase.database.DatabaseReference;
 import com.google.firebase.database.FirebaseDatabase;
-import com.google.firebase.database.MutableData;
-import com.google.firebase.database.Transaction;
 import com.google.firebase.database.ValueEventListener;
 
 import java.text.DateFormat;
@@ -41,10 +33,8 @@ import pitcherseye.pitcherseye.Objects.PitcherStats;
 import pitcherseye.pitcherseye.R;
 import pitcherseye.pitcherseye.Utilities;
 
-import static java.lang.Math.round;
-
-    public class TaggingActivity extends Activity implements EventInfoFragment.OnInputListener, ResultsFragment.OnInputListener,
-                                                            ChangePitcherFragment.OnInputListener {
+public class TaggingActivity extends Activity implements EventInfoFragment.OnInputListener, ResultsFragment.OnInputListener,
+        ChangePitcherFragment.OnInputListener {
 
     // Buttons
     Button mR1C1;
@@ -250,7 +240,7 @@ import static java.lang.Math.round;
             public void onDataChange(DataSnapshot dataSnapshot) {
                 final List<String> pitchers = new ArrayList<String>();
                 pitchers.add(" ");
-                for (DataSnapshot areaSnapshot: dataSnapshot.getChildren()) {
+                for (DataSnapshot areaSnapshot : dataSnapshot.getChildren()) {
                     String pitcherFName = areaSnapshot.child("fname").getValue(String.class);
                     String pitcherLName = areaSnapshot.child("lname").getValue(String.class);
                     String pitcherFullName = pitcherFName + " " + pitcherLName;
@@ -665,7 +655,7 @@ import static java.lang.Math.round;
     private void sendEventStats(String eventID, String eventName, String eventDate, Boolean isGame, Boolean isHome,
                                 int playerID, int teamID, int pitchCount, int strikeCount, int eventBallCount,
                                 int eventBallCountLow, int eventBallCountHigh, int eventBallCountLeft, int eventBallCountRight,
-                                int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
+                                int R1C1Count, int R1C2Count, int R1C3Count, int R2C1Count, int R2C2Count,
                                 int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int eventFastballCount,
                                 int eventChangeupCount, int eventCurveballCount, int eventSliderCount, int eventOtherCount) {
         // Defaulting some statistics to 0 until we establish further IDs
@@ -683,7 +673,7 @@ import static java.lang.Math.round;
     private void sendPitcherStats(String eventID, String eventName, String eventDate, Boolean isGame, Boolean isHome,
                                   int playerID, String pitcherName, int teamID, int pitchCount, int strikeCount, int pitcherBallCount,
                                   int pitcherBallCountLow, int pitcherBallCountHigh, int pitcherBallCountLeft, int pitcherBallCountRight,
-                                  int R1C1Count, int R1C2Count,  int R1C3Count, int R2C1Count, int R2C2Count,
+                                  int R1C1Count, int R1C2Count, int R1C3Count, int R2C1Count, int R2C2Count,
                                   int R2C3Count, int R3C1Count, int R3C2Count, int R3C3Count, int fastballCount,
                                   int changeupCount, int curveballCount, int sliderCount, int otherCount) {
 
@@ -719,15 +709,15 @@ import static java.lang.Math.round;
     }
 
     private void adjustHeatMap() {
-        mR1C1.getBackground().setAlpha(pitcherCount_R1C1  * 255 / pitcherPitchCount);
-        mR1C2.getBackground().setAlpha(pitcherCount_R1C2  * 255 / pitcherPitchCount);
-        mR1C3.getBackground().setAlpha(pitcherCount_R1C3  * 255 / pitcherPitchCount);
-        mR2C1.getBackground().setAlpha(pitcherCount_R2C1  * 255 / pitcherPitchCount);
-        mR2C2.getBackground().setAlpha(pitcherCount_R2C2  * 255 / pitcherPitchCount);
-        mR2C3.getBackground().setAlpha(pitcherCount_R2C3  * 255 / pitcherPitchCount);
-        mR3C1.getBackground().setAlpha(pitcherCount_R3C1  * 255 / pitcherPitchCount);
-        mR3C2.getBackground().setAlpha(pitcherCount_R3C2  * 255 / pitcherPitchCount);
-        mR3C3.getBackground().setAlpha(pitcherCount_R3C3  * 255 / pitcherPitchCount);
+        mR1C1.getBackground().setAlpha(pitcherCount_R1C1 * 255 / pitcherPitchCount);
+        mR1C2.getBackground().setAlpha(pitcherCount_R1C2 * 255 / pitcherPitchCount);
+        mR1C3.getBackground().setAlpha(pitcherCount_R1C3 * 255 / pitcherPitchCount);
+        mR2C1.getBackground().setAlpha(pitcherCount_R2C1 * 255 / pitcherPitchCount);
+        mR2C2.getBackground().setAlpha(pitcherCount_R2C2 * 255 / pitcherPitchCount);
+        mR2C3.getBackground().setAlpha(pitcherCount_R2C3 * 255 / pitcherPitchCount);
+        mR3C1.getBackground().setAlpha(pitcherCount_R3C1 * 255 / pitcherPitchCount);
+        mR3C2.getBackground().setAlpha(pitcherCount_R3C2 * 255 / pitcherPitchCount);
+        mR3C3.getBackground().setAlpha(pitcherCount_R3C3 * 255 / pitcherPitchCount);
         mBallLow.getBackground().setAlpha(pitcherBallsCountLow * 255 / pitcherPitchCount);
         mBallHigh.getBackground().setAlpha(pitcherBallsCountHigh * 255 / pitcherPitchCount);
         mBallLeft.getBackground().setAlpha(pitcherBallsCountLeft * 255 / pitcherPitchCount);
@@ -917,10 +907,10 @@ import static java.lang.Math.round;
         }
     }
 
-    // Use this as a helper so we can call sendPitcherStats from EventInfoFragment TODO THIS IS WHERE STUFF
+    // Use this as a helper so we can call sendPitcherStats from EventInfoFragment
     public void sendPitcherStatsHelper() {
         sendPitcherStats(eventID, eventName, eventDate, isGame, isHome, 0,
-                pitcherName,0, pitcherPitchCount, pitcherStrikesCount,
+                pitcherName, 0, pitcherPitchCount, pitcherStrikesCount,
                 pitcherBallsCount, pitcherBallsCountLow, pitcherBallsCountHigh, pitcherBallsCountLeft, pitcherBallsCountRight,
                 pitcherCount_R1C1, pitcherCount_R1C2, pitcherCount_R1C3, pitcherCount_R2C1,
                 pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
@@ -959,7 +949,7 @@ import static java.lang.Math.round;
         mProgressFinishGame.setVisibility(View.VISIBLE);
 
         // Send event stats
-        sendEventStats(eventID, eventName, eventDate, isGame, isHome,0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
+        sendEventStats(eventID, eventName, eventDate, isGame, isHome, 0, 0, eventPitchCount, eventStrikesCount, eventBallsCount,
                 eventBallsCountLow, eventBallsCountHigh, eventBallsCountLeft, eventBallsCountRight,
                 eventCount_R1C1, eventCount_R1C2, eventCount_R1C3, eventCount_R2C1, eventCount_R2C2, eventCount_R2C3,
                 eventCount_R3C1, eventCount_R3C2, eventCount_R3C3, eventFastballCount, eventChangeupCount,
@@ -967,7 +957,7 @@ import static java.lang.Math.round;
 
         // Send individual stats as well
         sendPitcherStats(eventID, eventName, eventDate, isGame, isHome, 0,
-                pitcherName,0, pitcherPitchCount, pitcherStrikesCount,
+                pitcherName, 0, pitcherPitchCount, pitcherStrikesCount,
                 pitcherBallsCount, pitcherBallsCountLow, pitcherBallsCountHigh, pitcherBallsCountLeft, pitcherBallsCountRight,
                 pitcherCount_R1C1, pitcherCount_R1C2, pitcherCount_R1C3, pitcherCount_R2C1,
                 pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
@@ -1005,7 +995,7 @@ import static java.lang.Math.round;
 
     @Override
     public void sendResultsInput(int pitcherFastballCount, int pitcherChangeupCount, int pitcherCurveballCount,
-                          int pitcherSliderCount, int pitcherOtherCount) {
+                                 int pitcherSliderCount, int pitcherOtherCount) {
         mPitcherFastballCount.setText(Integer.toString(pitcherFastballCount));
         mPitcherChangeupCount.setText(Integer.toString(pitcherChangeupCount));
         mPitcherCurveballCount.setText(Integer.toString(pitcherCurveballCount));
@@ -1026,13 +1016,17 @@ import static java.lang.Math.round;
         return isGame;
     }
 
-    public void setGame(Boolean game) { isGame = game; }
+    public void setGame(Boolean game) {
+        isGame = game;
+    }
 
     public Boolean getHome() {
         return isHome;
     }
 
-    public void setHome(Boolean home) { isHome = home; }
+    public void setHome(Boolean home) {
+        isHome = home;
+    }
 
     public String getPitcherName() {
         return pitcherName;
@@ -1046,9 +1040,13 @@ import static java.lang.Math.round;
         return pitcherPitchCount;
     }
 
-    public Boolean getEventInfoSet() { return eventInfoSet; }
+    public Boolean getEventInfoSet() {
+        return eventInfoSet;
+    }
 
-    public void setEventInfoSet(Boolean eventInfoSet) { this.eventInfoSet = eventInfoSet; }
+    public void setEventInfoSet(Boolean eventInfoSet) {
+        this.eventInfoSet = eventInfoSet;
+    }
 
     @Override
     public void onBackPressed() {

--- a/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.app.DialogFragment;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -63,6 +64,23 @@ public class EventInfoFragment extends DialogFragment {
 
         // Make sure the user can't exit the DialogFragment without confirming their input
         getDialog().setCanceledOnTouchOutside(false);
+
+        // Disable the back button on selection
+        view.setFocusableInTouchMode(true);
+        view.requestFocus();
+        view.setOnKeyListener(new View.OnKeyListener(){
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                    if (keyCode == KeyEvent.KEYCODE_BACK) {
+                        Toast.makeText(getActivity(), "Please enter event info", Toast.LENGTH_SHORT).show();
+                        Log.i("Back Pressed", "EventInfoFragment");
+                        return true;
+                    }
+                }
+                return false;
+            }
+        });
 
         isGame = taggingActivity.getGame();
         isHome = taggingActivity.getHome();

--- a/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
@@ -1,9 +1,9 @@
 package pitcherseye.pitcherseye.Fragments;
 
+import android.app.DialogFragment;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.app.DialogFragment;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -32,6 +32,7 @@ import pitcherseye.pitcherseye.R;
 
 public class EventInfoFragment extends DialogFragment {
 
+    public OnInputListener mOnInputListener;
     Button mConfirmChange;
     RadioGroup mRadioGroupEventType;
     RadioButton mRadioGame;
@@ -43,18 +44,10 @@ public class EventInfoFragment extends DialogFragment {
     EditText mEventName;
     Spinner mSpinnerPitchers;
     TextView mEventInfo;
-
     Boolean isGame;
     Boolean isHome;
-
     String pitcherName = "";
     String eventName = "";
-
-    public interface OnInputListener {
-        void sendInput(String eventName, Boolean isGame, Boolean isHome, String pitcherName, int pitcherSpinnerIndex);
-    }
-
-    public OnInputListener mOnInputListener;
 
     @Nullable
     @Override
@@ -66,12 +59,14 @@ public class EventInfoFragment extends DialogFragment {
         getDialog().setCanceledOnTouchOutside(false);
 
         // Disable the back button on selection
+        // We'll check if the original event info is set, if it hasn't been, disable the back button.
+        // If it HAS been set, enable the back button in case the user wants to keep tagging.
         view.setFocusableInTouchMode(true);
         view.requestFocus();
-        view.setOnKeyListener(new View.OnKeyListener(){
+        view.setOnKeyListener(new View.OnKeyListener() {
             @Override
             public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                if (!taggingActivity.getEventInfoSet()) {
                     if (keyCode == KeyEvent.KEYCODE_BACK) {
                         Toast.makeText(getActivity(), "Please enter event info", Toast.LENGTH_SHORT).show();
                         Log.i("Back Pressed", "EventInfoFragment");
@@ -97,7 +92,7 @@ public class EventInfoFragment extends DialogFragment {
         mRadioHome = (RadioButton) view.findViewById(R.id.radio_event_location_home);
         mRadioAway = (RadioButton) view.findViewById(R.id.radio_event_location_away);
 
-       // Check to see if we are finishing the game or doing the initial entry
+        // Check to see if we are finishing the game or doing the initial entry
         if (taggingActivity.getEventInfoSet()) {
             mEventInfo.setText("Confirm Information");
             mConfirmChange.setText("Finish Event");
@@ -107,8 +102,12 @@ public class EventInfoFragment extends DialogFragment {
             mEventName.setText(taggingActivity.getEventName());
         }
 
-        if (!isGame) { mRadioPractice.setChecked(true); }
-        if (!isHome) { mRadioAway.setChecked(true); }
+        if (!isGame) {
+            mRadioPractice.setChecked(true);
+        }
+        if (!isHome) {
+            mRadioAway.setChecked(true);
+        }
 
         // Instantiate and load pitchers into spinner
         mDatabase.child("users").addValueEventListener(new ValueEventListener() {
@@ -177,7 +176,7 @@ public class EventInfoFragment extends DialogFragment {
                     // Check to make sure there is an entry in the spinner
                     if (mEventName.getText().toString().trim().isEmpty()) {
                         Toast.makeText(getActivity(), "Enter an event name to start session", Toast.LENGTH_SHORT).show();
-                    } else if (mSpinnerPitchers.getSelectedItem().toString().trim().isEmpty()  || mSpinnerPitchers.getSelectedItem().toString().trim().equals("<Select Pitcher>")) {
+                    } else if (mSpinnerPitchers.getSelectedItem().toString().trim().isEmpty() || mSpinnerPitchers.getSelectedItem().toString().trim().equals("<Select Pitcher>")) {
                         Toast.makeText(getActivity().getApplicationContext(), "Enter a pitcher to start session", Toast.LENGTH_SHORT).show();
                     } else if (mSpinnerPitchers.getSelectedItem().toString().trim().equals(taggingActivity.getPitcherName()) && taggingActivity.getEventInfoSet()) {
                         getDialog().dismiss();
@@ -213,8 +212,12 @@ public class EventInfoFragment extends DialogFragment {
         super.onAttach(context);
         try {
             mOnInputListener = (OnInputListener) getActivity();
-        } catch (ClassCastException cce){
+        } catch (ClassCastException cce) {
             Log.e("CCE", "onAttach: ClassCastException: " + cce.getMessage());
         }
+    }
+
+    public interface OnInputListener {
+        void sendInput(String eventName, Boolean isGame, Boolean isHome, String pitcherName, int pitcherSpinnerIndex);
     }
 }

--- a/app/src/main/java/pitcherseye/pitcherseye/Fragments/ResultsFragment.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Fragments/ResultsFragment.java
@@ -3,10 +3,13 @@ package pitcherseye.pitcherseye.Fragments;
 import android.app.DialogFragment;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.util.Log;
+import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.Toast;
 
 import pitcherseye.pitcherseye.Activities.TaggingActivity;
 import pitcherseye.pitcherseye.R;
@@ -50,6 +53,23 @@ public class ResultsFragment extends DialogFragment {
 
         // Make sure the user can't exit the DialogFragment without confirming their input
         getDialog().setCanceledOnTouchOutside(false);
+
+        // Disable the back button on selection
+        view.setFocusableInTouchMode(true);
+        view.requestFocus();
+        view.setOnKeyListener(new View.OnKeyListener(){
+            @Override
+            public boolean onKey(View v, int keyCode, KeyEvent event) {
+                if (event.getAction() == KeyEvent.ACTION_DOWN) {
+                    if (keyCode == KeyEvent.KEYCODE_BACK) {
+                        Toast.makeText(getActivity(), "Please select a pitch result", Toast.LENGTH_SHORT).show();
+                        Log.i("Back Pressed", "ResultsFragment");
+                        return true;
+                    }
+                }
+                return false;
+            }
+        });
 
         // Buttons
         mFastball = (Button) view.findViewById(R.id.btn_result_fastball);

--- a/app/src/main/java/pitcherseye/pitcherseye/Fragments/ResultsFragment.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Fragments/ResultsFragment.java
@@ -20,12 +20,12 @@ import pitcherseye.pitcherseye.R;
 
 public class ResultsFragment extends DialogFragment {
 
+    public OnInputListener mOnInputResultsListener;
     Button mFastball;
     Button mChangeup;
     Button mCurveball;
     Button mSlider;
     Button mOther;
-
     int pitcherFastballCount;
     int eventFastballCount;
     int pitcherChangeupCount;
@@ -36,15 +36,7 @@ public class ResultsFragment extends DialogFragment {
     int eventSliderCount;
     int pitcherOtherCount;
     int eventOtherCount;
-
     TaggingActivity taggingActivity = (TaggingActivity) getActivity();
-
-    public interface OnInputListener {
-        void sendResultsInput(int pitcherFastballCount, int pitcherChangeupCount, int pitcherCurveballCount,
-                       int pitcherSliderCount, int pitcherOtherCount);
-    }
-
-    public OnInputListener mOnInputResultsListener;
 
     @Nullable
     @Override
@@ -57,15 +49,13 @@ public class ResultsFragment extends DialogFragment {
         // Disable the back button on selection
         view.setFocusableInTouchMode(true);
         view.requestFocus();
-        view.setOnKeyListener(new View.OnKeyListener(){
+        view.setOnKeyListener(new View.OnKeyListener() {
             @Override
             public boolean onKey(View v, int keyCode, KeyEvent event) {
-                if (event.getAction() == KeyEvent.ACTION_DOWN) {
-                    if (keyCode == KeyEvent.KEYCODE_BACK) {
-                        Toast.makeText(getActivity(), "Please select a pitch result", Toast.LENGTH_SHORT).show();
-                        Log.i("Back Pressed", "ResultsFragment");
-                        return true;
-                    }
+                if (keyCode == KeyEvent.KEYCODE_BACK) {
+                    Toast.makeText(getActivity(), "Please select a pitch result", Toast.LENGTH_SHORT).show();
+                    Log.i("Back Pressed", "ResultsFragment");
+                    return true;
                 }
                 return false;
             }
@@ -138,5 +128,10 @@ public class ResultsFragment extends DialogFragment {
         });
 
         return view;
+    }
+
+    public interface OnInputListener {
+        void sendResultsInput(int pitcherFastballCount, int pitcherChangeupCount, int pitcherCurveballCount,
+                              int pitcherSliderCount, int pitcherOtherCount);
     }
 }


### PR DESCRIPTION
## [Overview](#overview)
This should be an easier one and will probably conclude the features implemented before the presentation. 

This disables the back button in both the ResultsFragment and EventInfoFragment so the user must enter valid inputs. We do enable the back key for EventInfoFragment for finishing the event so the user can keep tagging if desired.

This also implements an AlertDialog to have the user confirm the deletion of RecyclerView items.

## [Background Context](#background)
Will add later

## [Illustrations](#illustrations)

## [Acceptance Criteria](#acceptance-criteria)
 - [x] Users can't exit the initial EventInfoFragment without inputting information.
 - [x] Users CAN exit the EventInfoFragment when finishing the event
 - [x] Users can't exit the ResultsFragment without inputting information
 - [x] When deleting an item in the RecylerView, a dialog will appear that will ask the user to confirm the deletion of the event
 - [x] Deleting the item will reflect in Firebase and canceling the deletion will not do anything