### PR TITLE
Fix EventInfoFragment Crash

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,7 +24,8 @@
             android:screenOrientation="sensorLandscape"/>
         <activity android:name=".Activities.StatisticsActivity" />
         <activity android:name=".Activities.TaggingActivity"
-            android:screenOrientation="sensorLandscape"/>
+            android:screenOrientation="sensorLandscape"
+            android:noHistory="true"/>
         <activity
             android:name=".Activities.SignUpActivity"
             android:windowSoftInputMode="stateHidden" />

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -964,10 +964,6 @@ public class TaggingActivity extends Activity implements EventInfoFragment.OnInp
                 pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
                 pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
 
-        // TODO
-        EventInfoFragment eventInfoFragment = new EventInfoFragment();
-        getFragmentManager().beginTransaction().remove(eventInfoFragment).commitAllowingStateLoss();
-
         // Send back to MainActivity
         Intent i = MainActivity.newIntent(TaggingActivity.this);
         startActivityForResult(i, REQUEST_CODE_CALCULATE);

--- a/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Activities/TaggingActivity.java
@@ -964,6 +964,10 @@ public class TaggingActivity extends Activity implements EventInfoFragment.OnInp
                 pitcherCount_R2C2, pitcherCount_R2C3, pitcherCount_R3C1, pitcherCount_R3C2, pitcherCount_R3C3,
                 pitcherFastballCount, pitcherChangeupCount, pitcherCurveballCount, pitcherSliderCount, pitcherOtherCount);
 
+        // TODO
+        EventInfoFragment eventInfoFragment = new EventInfoFragment();
+        getFragmentManager().beginTransaction().remove(eventInfoFragment).commitAllowingStateLoss();
+
         // Send back to MainActivity
         Intent i = MainActivity.newIntent(TaggingActivity.this);
         startActivityForResult(i, REQUEST_CODE_CALCULATE);

--- a/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
+++ b/app/src/main/java/pitcherseye/pitcherseye/Fragments/EventInfoFragment.java
@@ -1,12 +1,9 @@
 package pitcherseye.pitcherseye.Fragments;
 
 import android.app.DialogFragment;
-import android.app.FragmentManager;
 import android.content.Context;
 import android.os.Bundle;
-import android.renderscript.Sampler;
 import android.support.annotation.Nullable;
-import android.support.v4.app.FragmentActivity;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;


### PR DESCRIPTION
We found out that tagging an event, logging out and registering a new user was triggering the EventInfoFragment's onDataChange method and causing a crash. This rewrites the life cycle of the fragment to destroy the event listener onStop and onPause.